### PR TITLE
Reenable min/max for OMERO script parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>net.imagej</groupId>
 		<artifactId>pom-imagej</artifactId>
-		<version>7.0.0</version>
+		<version>8.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -105,12 +105,10 @@ public class DefaultOMEROService extends AbstractService implements
 		if (choices != null && !choices.isEmpty()) {
 			param.values = (omero.RList) toOMERO(choices);
 		}
-		// TEMP: Disabled until OME issue #11472 is resolved
-		// https://trac.openmicroscopy.org.uk/ome/ticket/11472
-//		final Object min = item.getMinimumValue();
-//		if (min != null) param.min = toOMERO(min);
-//		final Object max = item.getMaximumValue();
-//		if (max != null) param.max = toOMERO(max);
+		final Object min = item.getMinimumValue();
+		if (min != null) param.min = toOMERO(min);
+		final Object max = item.getMaximumValue();
+		if (max != null) param.max = toOMERO(max);
 		return param;
 	}
 


### PR DESCRIPTION
Min/max parameters were disabled due to a bug in SciJava Common: non-numeric parameters—particularly string parameters—had their min and max set to the empty string, due to how Java annotation types work.

The relevant upstream fix is:
scijava/scijava-common@d5b58e4a4d29518523de83c6e1c08a1eca7a11d6