### PR TITLE
Add Tables functionality to ImageJ-OMERO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,14 @@
 		</dependency>
 
 		<!-- Test dependencies -->
+		<!-- JMockit must come before junit -->
+		<dependency>
+			<groupId>org.jmockit</groupId>
+			<artifactId>jmockit</artifactId>
+			<version>1.10</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -176,4 +184,22 @@
 			<version>3.2.2</version>
 		</dependency>
 	</dependencies>
+
+	<!-- NB: JUnit and JMockit both contain the JUnit runner class -->
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<configuration>
+					<rules>
+						<banDuplicateClasses>
+							<ignoreClasses>
+								<ignoreClass>org.junit.runner.Runner</ignoreClass>
+							</ignoreClasses>
+						</banDuplicateClasses>
+					</rules>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,15 +132,7 @@
 		<!-- ImageJ dependencies -->
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>ij</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
 			<artifactId>imagej-common</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-legacy</artifactId>
 		</dependency>
 
 		<!-- SCIFIO dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -168,5 +168,12 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Apache dependencies -->
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.2</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,12 @@
 			<artifactId>commons-collections</artifactId>
 			<version>3.2.2</version>
 		</dependency>
+
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
 	</dependencies>
 
 	<!-- NB: JUnit and JMockit both contain the JUnit runner class -->

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 		<dependency>
 			<groupId>org.jmockit</groupId>
 			<artifactId>jmockit</artifactId>
-			<version>1.10</version>
+			<version>1.33</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -178,9 +178,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.collections</groupId>
-			<artifactId>google-collections</artifactId>
-			<version>1.0-rc2</version>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>12.0.0</version>
+		<version>16.2.0</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.google.collections</groupId>
+			<artifactId>google-collections</artifactId>
+			<version>1.0-rc2</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Apache dependencies -->
 		<dependency>
 			<groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 	- Glencoe Software, Inc.
 	- University of Dundee</license.copyrightOwners>
 	<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
-		<omero.version>5.2.0-ice35</omero.version>
+		<omero.version>5.3.0-ice36</omero.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -443,11 +443,13 @@ public class DefaultOMEROService extends AbstractService implements
 
 			final int batchSize = 24 * 1024;
 			int currentRow = 0;
+
 			final Column<?>[] imageJColumns = new Column<?>[colCount];
+			final long[] colIndices = new long[colCount];
+			for (int c = 0; c < colIndices.length; c++)
+				colIndices[c] = c;
+
 			while (currentRow < rowCount) {
-				final long[] colIndices = new long[colCount];
-				for (int c = 0; c < colIndices.length; c++)
-					colIndices[c] = c;
 				final int rowsLeft = rowCount - currentRow;
 				final int rowsToRead = Math.min(batchSize, rowsLeft);
 				final omero.grid.Data data =
@@ -472,6 +474,8 @@ public class DefaultOMEROService extends AbstractService implements
 				}
 				currentRow += rowsToRead;
 			}
+			//Need to specify how many rows the table has for data to display
+			imageJTable.setRowCount(rowCount);
 			return imageJTable;
 		}
 		finally {

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -378,10 +378,9 @@ public class DefaultOMEROService extends AbstractService implements
 		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
 		DSAccessException
 	{
-		final OMEROSession session = new DefaultOMEROSession(credentials);
 		TablePrx tableService = null;
 		long id = -1;
-		try {
+		try (final OMEROSession session = new DefaultOMEROSession(credentials)) {
 			tableService =
 				session.getClient().getSession().sharedResources().newTable(1, name);
 			if (tableService == null) {
@@ -403,14 +402,9 @@ public class DefaultOMEROService extends AbstractService implements
 			if (imageID != 0) attachAnnotation(session, imageID, tableService);
 		}
 		finally {
-			try {
-				if (tableService != null) {
-					id = tableService.getOriginalFile().getId().getValue();
-					tableService.close();
-				}
-			}
-			finally {
-				((DefaultOMEROSession) session).close();
+			if (tableService != null) {
+				id = tableService.getOriginalFile().getId().getValue();
+				tableService.close();
 			}
 		}
 		return id;
@@ -421,9 +415,8 @@ public class DefaultOMEROService extends AbstractService implements
 		final long tableID) throws ServerError, PermissionDeniedException,
 		CannotCreateSessionException
 	{
-		final OMEROSession session = new DefaultOMEROSession(credentials);
 		TablePrx tableService = null;
-		try {
+		try (final OMEROSession session = new DefaultOMEROSession(credentials)) {
 			final OriginalFile tableFile = new OriginalFileI(tableID, false);
 			tableService =
 				session.getClient().getSession().sharedResources().openTable(tableFile);
@@ -479,13 +472,8 @@ public class DefaultOMEROService extends AbstractService implements
 			return imageJTable;
 		}
 		finally {
-			try {
-				if (tableService != null) {
-					tableService.close();
-				}
-			}
-			finally {
-				((DefaultOMEROSession) session).close();
+			if (tableService != null) {
+				tableService.close();
 			}
 		}
 	}

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -253,9 +253,7 @@ public class DefaultOMEROService extends AbstractService implements
 			return toOMERO(client, imageDisplayService.getActiveDataset(imageDisplay));
 		}
 		if (value instanceof Table) {
-			final OMEROCredentials cred = createCredentials(client);
-			final long tableID = uploadTable(cred, "table", (Table<?, ?>) value, 0);
-			return toOMERO(client, tableID);
+			return convertOMEROTable((Table<?, ?>) value);
 		}
 		return toOMERO(value);
 	}

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -257,7 +257,7 @@ public class DefaultOMEROService extends AbstractService implements
 			return toOMERO(client, imageDisplayService.getActiveDataset(imageDisplay));
 		}
 		if (value instanceof Table) {
-			OMEROCredentials cred = createCredentials(client);
+			final OMEROCredentials cred = createCredentials(client);
 			final long tableID = uploadTable(cred, "table", (Table<?, ?>) value, 0);
 			return toOMERO(client, tableID);
 		}
@@ -459,8 +459,8 @@ public class DefaultOMEROService extends AbstractService implements
 				assert (colCount == data.columns.length);
 				// Create columns
 				if (!colCreated) {
-					if (GenericTable.class.isInstance(imageJTable))
-						addTypedColumns( (GenericTable) imageJTable, data, rowCount);
+					if (GenericTable.class.isInstance(imageJTable)) addTypedColumns(
+						(GenericTable) imageJTable, data, rowCount);
 					// Append empty columns of table type
 					else imageJTable.appendColumns(colCount);
 					colCreated = true;
@@ -474,7 +474,7 @@ public class DefaultOMEROService extends AbstractService implements
 				}
 				currentRow += rowsToRead;
 			}
-			//Need to specify how many rows the table has for data to display
+			// Need to specify how many rows the table has for data to display
 			imageJTable.setRowCount(rowCount);
 			return imageJTable;
 		}
@@ -519,6 +519,7 @@ public class DefaultOMEROService extends AbstractService implements
 	 * a specified ID and convert the result to the appropriate type of ImageJ
 	 * object such as {@link Dataset}.</li>
 	 * </ol>
+	 *
 	 * @throws CannotCreateSessionException
 	 * @throws PermissionDeniedException
 	 */
@@ -596,7 +597,7 @@ public class DefaultOMEROService extends AbstractService implements
 
 	/**
 	 * Attaches table file to OMERO image.
-	 * 
+	 *
 	 * @throws ExecutionException
 	 * @throws DSAccessException
 	 * @throws DSOutOfServiceException
@@ -606,17 +607,17 @@ public class DefaultOMEROService extends AbstractService implements
 		ExecutionException, DSOutOfServiceException, DSAccessException
 	{
 		// Create necessary facilities
-		DataManagerFacility dm =
+		final DataManagerFacility dm =
 			session.getGateway().getFacility(DataManagerFacility.class);
-		BrowseFacility browse =
+		final BrowseFacility browse =
 			session.getGateway().getFacility(BrowseFacility.class);
 
 		// Get current sessions security context
-		SecurityContext ctx =
+		final SecurityContext ctx =
 			new SecurityContext(session.getExperimenter().getGroupId());
 
 		// Get original file from the table
-		OriginalFile file = table.getOriginalFile();
+		final OriginalFile file = table.getOriginalFile();
 
 		// Create file annotation for table file
 		FileAnnotation annotation = new FileAnnotationI();
@@ -635,7 +636,7 @@ public class DefaultOMEROService extends AbstractService implements
 		link = (ImageAnnotationLink) dm.saveAndReturnObject(ctx, link);
 	}
 
-	private OMEROCredentials createCredentials(omero.client client) {
+	private OMEROCredentials createCredentials(final omero.client client) {
 		final OMEROCredentials credentials = new OMEROCredentials();
 		credentials.setServer(client.getProperty("omero.host"));
 		credentials.setPort(Integer.parseInt(client.getProperty("omero.port")));

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -48,6 +48,7 @@ import net.imagej.display.ImageDisplayService;
 import net.imagej.table.Column;
 import net.imagej.table.GenericTable;
 import net.imagej.table.Table;
+import net.imagej.table.TableDisplay;
 
 import org.scijava.Optional;
 import org.scijava.convert.ConvertService;
@@ -134,7 +135,9 @@ public class DefaultOMEROService extends AbstractService implements
 		}
 
 		// table
-		if (Table.class.isAssignableFrom(type)) {
+		if (Table.class.isAssignableFrom(type) || TableDisplay.class
+			.isAssignableFrom(type))
+		{
 			// table file ID
 			return omero.rtypes.rlong(0);
 		}
@@ -260,6 +263,9 @@ public class DefaultOMEROService extends AbstractService implements
 		}
 		if (value instanceof Table) {
 			return convertOMEROTable((Table<?, ?>) value);
+		}
+		if (value instanceof TableDisplay) {
+			return toOMERO(client, ((TableDisplay) value).get(0));
 		}
 		return toOMERO(value);
 	}

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -133,6 +133,12 @@ public class DefaultOMEROService extends AbstractService implements
 			return omero.rtypes.rlong(0);
 		}
 
+		// table
+		if (Table.class.isAssignableFrom(type)) {
+			// table file ID
+			return omero.rtypes.rlong(0);
+		}
+
 		// primitive types
 		final Class<?> saneType = ConversionUtils.getNonprimitiveType(type);
 		if (Boolean.class.isAssignableFrom(saneType)) {

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -378,7 +378,7 @@ public class DefaultOMEROService extends AbstractService implements
 		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
 		DSAccessException
 	{
-		final OMEROSession session = new OMEROSession(credentials);
+		final OMEROSession session = new DefaultOMEROSession(credentials);
 		TablePrx tableService = null;
 		long id = -1;
 		try {
@@ -410,7 +410,7 @@ public class DefaultOMEROService extends AbstractService implements
 				}
 			}
 			finally {
-				session.close();
+				((DefaultOMEROSession) session).close();
 			}
 		}
 		return id;
@@ -421,7 +421,7 @@ public class DefaultOMEROService extends AbstractService implements
 		final long tableID) throws ServerError, PermissionDeniedException,
 		CannotCreateSessionException
 	{
-		final OMEROSession session = new OMEROSession(credentials);
+		final OMEROSession session = new DefaultOMEROSession(credentials);
 		TablePrx tableService = null;
 		try {
 			final OriginalFile tableFile = new OriginalFileI(tableID, false);
@@ -485,7 +485,7 @@ public class DefaultOMEROService extends AbstractService implements
 				}
 			}
 			finally {
-				session.close();
+				((DefaultOMEROSession) session).close();
 			}
 		}
 	}

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -27,7 +27,6 @@ package net.imagej.omero;
 
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
-import ij.ImagePlus;
 import io.scif.Metadata;
 import io.scif.services.DatasetIOService;
 
@@ -47,8 +46,6 @@ import net.imagej.Dataset;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
 import net.imagej.display.ImageDisplayService;
-import net.imagej.legacy.LegacyService;
-import net.imagej.patcher.LegacyInjector;
 import net.imagej.table.Column;
 import net.imagej.table.DoubleColumn;
 import net.imagej.table.GenericColumn;
@@ -83,11 +80,6 @@ public class DefaultOMEROService extends AbstractService implements
 	OMEROService, Optional
 {
 
-	static {
-		// NB: Necessary to avoid class-loading issues with the patched ImageJ1.
-		LegacyInjector.preinit();
-	}
-
 	// -- Parameters --
 
 	@Parameter
@@ -104,9 +96,6 @@ public class DefaultOMEROService extends AbstractService implements
 
 	@Parameter
 	private ObjectService objectService;
-
-	@Parameter
-	private LegacyService legacyService;
 
 	@Parameter
 	private ConvertService convertService;
@@ -135,8 +124,7 @@ public class DefaultOMEROService extends AbstractService implements
 		// image types
 		if (Dataset.class.isAssignableFrom(type) ||
 			DatasetView.class.isAssignableFrom(type) ||
-			ImageDisplay.class.isAssignableFrom(type) ||
-			ImagePlus.class.isAssignableFrom(type))
+			ImageDisplay.class.isAssignableFrom(type))
 		{
 			// use an image ID
 			return omero.rtypes.rlong(0);
@@ -258,12 +246,6 @@ public class DefaultOMEROService extends AbstractService implements
 			final ImageDisplay imageDisplay = (ImageDisplay) value;
 			// TODO: Support more aspects of image displays; e.g., multiple datasets.
 			return toOMERO(client, imageDisplayService.getActiveDataset(imageDisplay));
-		}
-		if (value instanceof ImagePlus) {
-			final ImagePlus imp = (ImagePlus) value;
-			final ImageDisplay imageDisplay =
-				legacyService.getImageMap().registerLegacyImage(imp);
-			return toOMERO(client, imageDisplay);
 		}
 		return toOMERO(value);
 	}
@@ -563,12 +545,6 @@ public class DefaultOMEROService extends AbstractService implements
 				@SuppressWarnings("unchecked")
 				final T display = (T) displayService.createDisplay(dataset);
 				return display;
-			}
-			if (ImagePlus.class.isAssignableFrom(type)) {
-				final ImageDisplay display = convert(client, value, ImageDisplay.class);
-				@SuppressWarnings("unchecked")
-				final T imp = (T) legacyService.getImageMap().registerDisplay(display);
-				return imp;
 			}
 		}
 

--- a/src/main/java/net/imagej/omero/DefaultOMEROService.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROService.java
@@ -595,14 +595,10 @@ public class DefaultOMEROService extends AbstractService implements
 		ExecutionException, DSOutOfServiceException, DSAccessException
 	{
 		// Create necessary facilities
-		final DataManagerFacility dm =
-			session.getGateway().getFacility(DataManagerFacility.class);
-		final BrowseFacility browse =
-			session.getGateway().getFacility(BrowseFacility.class);
-
-		// Get current sessions security context
-		final SecurityContext ctx =
-			new SecurityContext(session.getExperimenter().getGroupId());
+		final DataManagerFacility dm = session.getGateway().getFacility(
+			DataManagerFacility.class);
+		final BrowseFacility browse = session.getGateway().getFacility(
+			BrowseFacility.class);
 
 		// Get original file from the table
 		final OriginalFile file = table.getOriginalFile();
@@ -610,18 +606,21 @@ public class DefaultOMEROService extends AbstractService implements
 		// Create file annotation for table file
 		FileAnnotation annotation = new FileAnnotationI();
 		// TODO assign annotation to a table namespace
-		annotation.setNs(omero.rtypes
-			.rstring(omero.constants.namespaces.NSBULKANNOTATIONS.value));
+		annotation.setNs(omero.rtypes.rstring(
+			omero.constants.namespaces.NSBULKANNOTATIONS.value));
 		annotation.setFile(file);
 		// Save file annotation to database
-		annotation = (FileAnnotation) dm.saveAndReturnObject(ctx, annotation);
+		annotation = (FileAnnotation) dm.saveAndReturnObject(session
+			.getSecurityContext(), annotation);
 
 		// Attach file to image with given ID
 		ImageAnnotationLink link = new ImageAnnotationLinkI();
 		link.setChild(annotation);
-		link.setParent(browse.getImage(ctx, imageID).asImage());
+		link.setParent(browse.getImage(session.getSecurityContext(), imageID)
+			.asImage());
 		// Save linkage to database
-		link = (ImageAnnotationLink) dm.saveAndReturnObject(ctx, link);
+		link = (ImageAnnotationLink) dm.saveAndReturnObject(session
+			.getSecurityContext(), link);
 	}
 
 	private OMEROCredentials createCredentials(final omero.client client) {

--- a/src/main/java/net/imagej/omero/DefaultOMEROSession.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROSession.java
@@ -1,0 +1,362 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import io.scif.FormatException;
+import io.scif.ImageMetadata;
+import io.scif.util.FormatTools;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import omero.RLong;
+import omero.ServerError;
+import omero.api.RawPixelsStorePrx;
+import omero.api.ServiceFactoryPrx;
+import omero.gateway.Gateway;
+import omero.gateway.LoginCredentials;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.model.ExperimenterData;
+import omero.gateway.model.ImageData;
+import omero.log.Logger;
+import omero.log.SimpleLogger;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.Pixels;
+import omero.model.PixelsType;
+
+/**
+ * Helper class for managing OMERO client sessions.
+ * 
+ * @author Curtis Rueden
+ */
+public class DefaultOMEROSession implements OMEROSession {
+
+	// -- Fields --
+
+	private omero.client client;
+	private ServiceFactoryPrx session;
+	private ExperimenterData experimenter;
+	private Gateway gateway;
+
+	// -- Constructors --
+
+	public DefaultOMEROSession(final OMEROCredentials credentials)
+		throws ServerError, PermissionDeniedException, CannotCreateSessionException
+	{
+		this(credentials, null);
+	}
+
+	public DefaultOMEROSession(final OMEROCredentials credentials,
+		final omero.client c) throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException
+	{
+		// initialize the client
+		boolean close = false;
+		if (c == null) {
+			final String server = credentials.getServer();
+			if (server != null) {
+				client = new omero.client(server, credentials.getPort());
+			}
+			else client = new omero.client();
+		}
+		else {
+			client = c;
+			close = true;
+		}
+
+		// initialize the session (i.e., log in)
+		final String sessionID = credentials.getSessionID();
+		if (sessionID != null) {
+			if (close) client.closeSession();
+			session = client.joinSession(sessionID);
+		}
+		else if (credentials.getUser() != null && credentials.getPassword() != null)
+		{
+			final String user = credentials.getUser();
+			final String password = credentials.getPassword();
+			setGateway();
+			setExperimenter(credentials);
+			session = client.createSession(user, password);
+			credentials.setSessionID(client.getSessionId());
+		}
+		else {
+			session = client.createSession();
+		}
+
+		// Until imagej-omero #30 is resolved; see:
+		// https://github.com/imagej/imagej-omero/issues/30
+//		if (client.isSecure() && !credentials.isEncrypted()) {
+//			client = client.createClient(false);
+//			session = client.getSession();
+//		}
+
+		session.detachOnDestroy();
+	}
+
+	// -- OMEROSession methods --
+
+	@Override
+	public omero.client getClient() {
+		return client;
+	}
+
+	@Override
+	public ServiceFactoryPrx getSession() {
+		return session;
+	}
+
+	@Override
+	public ExperimenterData getExperimenter() {
+		return experimenter;
+	}
+
+	@Override
+	public Gateway getGateway() {
+		return gateway;
+	}
+
+	@Override
+	public Pixels loadPixels(final OMEROFormat.Metadata meta) throws ServerError {
+		// return cached Pixels if available
+		Pixels pixels = meta.getPixels();
+		if (pixels != null) return pixels;
+
+		// NB: We cannot write:
+		//
+		// loadImage(meta).getPixels(0)
+		//
+		// because retrieving an Image is not enough to
+		// retrieve all fields of the linked Pixels.
+
+		// load the pixels ID from the remote server
+		final long pixelsID = loadPixelsID(meta);
+		meta.setPixelsID(pixelsID);
+
+		// load the Pixels from the remote server
+		pixels = session.getPixelsService().retrievePixDescription(pixelsID);
+		meta.setPixels(pixels);
+
+		return pixels;
+	}
+
+	@Override
+	public Image loadImage(final OMEROFormat.Metadata meta) throws ServerError {
+		// return cached Image if available
+		Image image = meta.getImage();
+		if (image != null) return image;
+
+		final long imageID = meta.getImageID();
+		if (imageID == 0) throw new IllegalArgumentException("Image ID is unset");
+
+		// load the Image from the remote server
+		final List<Long> ids = Arrays.asList(imageID);
+		final List<Image> images =
+			session.getContainerService().getImages("Image", ids, null);
+		if (images == null || images.isEmpty()) {
+			throw new IllegalArgumentException("Invalid image ID: " + imageID);
+		}
+		image = images.get(0);
+		meta.setImage(image);
+
+		return image;
+	}
+
+	@Override
+	public long loadPixelsID(final OMEROFormat.Metadata meta) throws ServerError {
+		// return cached pixels ID if available
+		long pixelsID = meta.getPixelsID();
+		if (pixelsID != 0) return pixelsID;
+
+		// obtain pixels ID from image ID
+		pixelsID = loadImage(meta).getPixels(0).getId().getValue();
+		meta.setPixelsID(pixelsID);
+
+		return pixelsID;
+	}
+
+	@Override
+	public String loadImageName(final OMEROFormat.Metadata meta)
+		throws ServerError
+	{
+		// return cached image name if available
+		String name = meta.getName();
+		if (name != null) return name;
+
+		// load the Image name from the remote server
+		name = loadImage(meta).getName().getValue();
+		meta.setName(name);
+
+		return name;
+	}
+
+	@Override
+	public RawPixelsStorePrx openPixels(final OMEROFormat.Metadata meta)
+		throws ServerError
+	{
+		final RawPixelsStorePrx store = session.createRawPixelsStore();
+		store.setPixelsId(loadPixelsID(meta), false);
+		return store;
+	}
+
+	@Override
+	public RawPixelsStorePrx createPixels(final OMEROFormat.Metadata meta)
+		throws ServerError, FormatException
+	{
+		// create a new Image which will house the written pixels
+		final ImageData newImage = createImage(meta);
+		final long imageID = newImage.getId();
+		meta.setImageID(imageID);
+
+		// configure the raw pixels store
+		final RawPixelsStorePrx store = session.createRawPixelsStore();
+		final long pixelsID = newImage.getDefaultPixels().getId();
+		store.setPixelsId(pixelsID, false);
+		meta.setPixelsID(pixelsID);
+
+		return store;
+	}
+
+	// -- Closeable methods --
+
+	@Override
+	public void close() {
+		if (client != null) client.__del__();
+		client = null;
+		session = null;
+		if (gateway != null) gateway.disconnect();
+	}
+
+	// -- Helper methods --
+
+	private ImageData createImage(final OMEROFormat.Metadata meta)
+		throws ServerError, FormatException
+	{
+		// create a new Image
+		final ImageMetadata imageMeta = meta.get(0);
+		final int xLen = axisLength(imageMeta, Axes.X);
+		final int yLen = axisLength(imageMeta, Axes.Y);
+		final int zLen = axisLength(imageMeta, Axes.Z);
+		final int tLen = axisLength(imageMeta, Axes.TIME);
+		final int cLen = axisLength(imageMeta, Axes.CHANNEL);
+		final int sizeX = xLen == 0 ? 1 : xLen;
+		final int sizeY = yLen == 0 ? 1 : yLen;
+		final int sizeZ = zLen == 0 ? 1 : zLen;
+		final int sizeT = tLen == 0 ? 1 : tLen;
+		final int sizeC = cLen == 0 ? 1 : cLen;
+		final List<Integer> channelList = new ArrayList<Integer>(sizeC);
+		for (int c = 0; c < sizeC; c++) {
+			// TODO: Populate actual emission wavelengths?
+			channelList.add(c);
+		}
+		final int pixelType = imageMeta.getPixelType();
+		final PixelsType pixelsType = getPixelsType(pixelType);
+		final String name = meta.getName();
+		final String description = meta.getName();
+		final RLong id =
+			session.getPixelsService().createImage(sizeX, sizeY, sizeZ, sizeT,
+				channelList, pixelsType, name, description);
+		if (id == null) throw new FormatException("Cannot create image");
+
+		// retrieve the newly created Image
+		final List<Image> results =
+			session.getContainerService().getImages(Image.class.getName(),
+				Arrays.asList(id.getValue()), null);
+		return new ImageData(results.get(0));
+	}
+
+	private PixelsType getPixelsType(final int pixelType) throws ServerError,
+		FormatException
+	{
+		return getPixelsType(FormatTools.getPixelTypeString(pixelType));
+	}
+
+	private PixelsType getPixelsType(final String pixelType) throws ServerError,
+		FormatException
+	{
+		final List<IObject> list =
+			session.getPixelsService().getAllEnumerations(PixelsType.class.getName());
+		final Iterator<IObject> iter = list.iterator();
+		while (iter.hasNext()) {
+			final PixelsType type = (PixelsType) iter.next();
+			final String value = type.getValue().getValue();
+			if (value.equals(pixelType)) return type;
+		}
+		throw new FormatException("Invalid pixel type: " + pixelType);
+	}
+
+	private int
+		axisLength(final ImageMetadata imageMeta, final AxisType axisType)
+			throws FormatException
+	{
+		final long axisLength = imageMeta.getAxisLength(axisType);
+		if (axisLength > Integer.MAX_VALUE) {
+			throw new FormatException("Length of " + axisType +
+				" axis is too large for OMERO: " + axisLength);
+		}
+		return (int) axisLength;
+	}
+
+	/**
+	 * Attempts to connect to the gateway using the given credentials. If it can
+	 * successfully connect, then it sets experimenter. 
+	 */
+	private void setExperimenter(OMEROCredentials credentials) throws ServerError
+	{
+		final LoginCredentials cred = new LoginCredentials();
+		cred.getServer().setHostname(credentials.getServer());
+		cred.getServer().setPort(credentials.getPort());
+		cred.getUser().setUsername(credentials.getUser());
+		cred.getUser().setPassword(credentials.getPassword());
+
+		if(gateway == null) setGateway();
+
+		try {
+			experimenter = gateway.connect(cred);
+		}
+		catch (DSOutOfServiceException exc) {
+			final ServerError err = new ServerError();
+			err.initCause(exc);
+			throw err;
+		}
+	}
+
+	/**
+	 * Creates a new gateway for the session.
+	 */
+	private void setGateway() {
+		final Logger simpleLogger = new SimpleLogger();
+		gateway = new Gateway(simpleLogger);
+	}
+
+}

--- a/src/main/java/net/imagej/omero/ModuleAdapter.java
+++ b/src/main/java/net/imagej/omero/ModuleAdapter.java
@@ -192,6 +192,9 @@ public class ModuleAdapter extends AbstractContextual {
 			if (value == null) {
 				log.warn(info.getTitle() + ": output '" + name + "' is null");
 			}
+			else if (net.imagej.table.Table.class.isAssignableFrom(item.getType())) {
+				client.setOutput(name + "table", value);
+			}
 			else client.setOutput(name, value);
 		}
 
@@ -457,7 +460,7 @@ public class ModuleAdapter extends AbstractContextual {
 			omero.RType output = client.getOutput(key);
 			if (!(output instanceof RLong)) continue;
 			final long id = ((RLong) output).getValue();
-			if(key.equals("table")) {
+			if(key.contains("table")) {
 				attachTableToImages(id, images, ctx);
 			}
 			else {
@@ -536,7 +539,7 @@ public class ModuleAdapter extends AbstractContextual {
 	private boolean containsImage() throws ServerError {
 		for (final String key : client.getOutputKeys()) {
 			omero.RType output = client.getOutput(key);
-			if (output instanceof RLong && !key.equals("table")) return true;
+			if (output instanceof RLong && !key.contains("table")) return true;
 		}
 		return false;
 	}

--- a/src/main/java/net/imagej/omero/ModuleAdapter.java
+++ b/src/main/java/net/imagej/omero/ModuleAdapter.java
@@ -470,7 +470,7 @@ public class ModuleAdapter extends AbstractContextual {
 			TablesFacility.class);
 
 		for (final String name : tables.keySet()) {
-			final TableData t = tablesFacility.addTable(ctx, images.get(0), "table",
+			final TableData t = tablesFacility.addTable(ctx, images.get(0), name,
 				tables.get(name));
 			client.setOutput(name, omero.rtypes.rlong(t.getOriginalFileId()));
 		}

--- a/src/main/java/net/imagej/omero/ModuleAdapter.java
+++ b/src/main/java/net/imagej/omero/ModuleAdapter.java
@@ -9,24 +9,21 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the 
+ * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public 
+ *
+ * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
 package net.imagej.omero;
-
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,6 +38,21 @@ import java.util.concurrent.Future;
 import net.imagej.Dataset;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
+
+import org.scijava.AbstractContextual;
+import org.scijava.Context;
+import org.scijava.ItemVisibility;
+import org.scijava.Versioned;
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.module.Module;
+import org.scijava.module.ModuleInfo;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
+import org.scijava.plugin.Parameter;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
 import omero.RLong;
 import omero.ServerError;
 import omero.gateway.Gateway;
@@ -61,18 +73,6 @@ import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
 import omero.model.OriginalFile;
 import omero.model.OriginalFileI;
-
-import org.scijava.AbstractContextual;
-import org.scijava.Context;
-import org.scijava.ItemVisibility;
-import org.scijava.Versioned;
-import org.scijava.command.Command;
-import org.scijava.log.LogService;
-import org.scijava.module.Module;
-import org.scijava.module.ModuleInfo;
-import org.scijava.module.ModuleItem;
-import org.scijava.module.ModuleService;
-import org.scijava.plugin.Parameter;
 
 /**
  * Adapts an ImageJ {@link Module} (such as a {@link Command}) to be usable as
@@ -155,6 +155,7 @@ public class ModuleAdapter extends AbstractContextual {
 
 	/**
 	 * Executes the associated ImageJ module as an OMERO script.
+	 * 
 	 * @throws IOException
 	 * @throws ServerError
 	 * @throws ExecutionException
@@ -164,17 +165,17 @@ public class ModuleAdapter extends AbstractContextual {
 	 * @throws DSOutOfServiceException
 	 */
 	public void launch() throws ServerError, IOException, ExecutionException,
-	PermissionDeniedException, CannotCreateSessionException,
-	DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		// populate inputs
 		log.debug(info.getTitle() + ": populating inputs");
-		final HashMap<String, Object> inputMap = new HashMap<String, Object>();
+		final HashMap<String, Object> inputMap = new HashMap<>();
 		for (final String name : client.getInputKeys()) {
 			final ModuleItem<?> input = getInput(name);
 			final Class<?> type = input.getType();
-			final Object value =
-					omeroService.toImageJ(client, client.getInput(name), type);
+			final Object value = omeroService.toImageJ(client, client.getInput(name),
+				type);
 			inputMap.put(input.getName(), value);
 		}
 
@@ -186,8 +187,8 @@ public class ModuleAdapter extends AbstractContextual {
 		// populate outputs
 		log.debug(info.getTitle() + ": populating outputs");
 		for (final ModuleItem<?> item : module.getInfo().outputs()) {
-			final omero.RType value =
-					omeroService.toOMERO(client, item.getValue(module));
+			final omero.RType value = omeroService.toOMERO(client, item.getValue(
+				module));
 			final String name = getOutputName(item);
 			if (value == null) {
 				log.warn(info.getTitle() + ": output '" + name + "' is null");
@@ -222,7 +223,7 @@ public class ModuleAdapter extends AbstractContextual {
 		final int outputDigits = String.valueOf(outputCount).length();
 
 		// convert metadata for each module input
-		params.inputs = new HashMap<String, omero.grid.Param>();
+		params.inputs = new HashMap<>();
 		int inputIndex = 0;
 		for (final ModuleItem<?> item : info.inputs()) {
 			if (item.getVisibility() == ItemVisibility.MESSAGE) continue;
@@ -234,7 +235,7 @@ public class ModuleAdapter extends AbstractContextual {
 		}
 
 		// convert metadata for each module output
-		params.outputs = new HashMap<String, omero.grid.Param>();
+		params.outputs = new HashMap<>();
 		int outputIndex = 0;
 		for (final ModuleItem<?> item : info.outputs()) {
 			final omero.grid.Param param = omeroService.getJobParam(item);
@@ -296,8 +297,8 @@ public class ModuleAdapter extends AbstractContextual {
 	}
 
 	/** Helper method for {@link #getInputName} and {@link #getOutputName}. */
-	private String
-	getName(final ModuleItem<?> item, final ModuleItem<?> imageItem)
+	private String getName(final ModuleItem<?> item,
+		final ModuleItem<?> imageItem)
 	{
 		if (imageItem != null && item.getName().equals(imageItem.getName())) {
 			return IMAGE_NAME;
@@ -327,9 +328,8 @@ public class ModuleAdapter extends AbstractContextual {
 		ModuleItem<?> imageItem = null;
 		for (final ModuleItem<?> item : items) {
 			final Class<?> type = item.getType();
-			if (Dataset.class.isAssignableFrom(type) ||
-					DatasetView.class.isAssignableFrom(type) ||
-					ImageDisplay.class.isAssignableFrom(type))
+			if (Dataset.class.isAssignableFrom(type) || DatasetView.class
+				.isAssignableFrom(type) || ImageDisplay.class.isAssignableFrom(type))
 			{
 				if (imageItem == null) imageItem = item;
 				else return null; // multiple image parameters
@@ -351,24 +351,28 @@ public class ModuleAdapter extends AbstractContextual {
 	 *
 	 * @throws ServerError
 	 * @throws ExecutionException
+	 * @throws DSAccessException
+	 * @throws DSOutOfServiceException
 	 */
-	private void createLinkages() throws ServerError, ExecutionException {
+	private void createLinkages() throws ServerError, ExecutionException,
+		DSOutOfServiceException, DSAccessException
+	{
 		// Create user
 		final ExperimenterData user = createUser();
 
-		if(user != null) {
+		if (user != null) {
 			final SecurityContext ctx = new SecurityContext(user.getGroupId());
 			final BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
 
 			// Get all input images from OMERO
-			final ArrayList<ImageData> images =
-					getInputImages(browse, ctx, new ArrayList<ImageData>());
+			final ArrayList<ImageData> images = getInputImages(browse, ctx,
+				new ArrayList<ImageData>());
 
-			if(!images.isEmpty()) {
-				final ArrayList<DatasetData> datasets = new ArrayList<DatasetData>();
-			// Get OMERO datasets associated with inputs only if output contains an
-			// image
-				if(containsImage()) getDatasets(browse, ctx, user, images, datasets);
+			if (!images.isEmpty()) {
+				final ArrayList<DatasetData> datasets = new ArrayList<>();
+				// Get OMERO datasets associated with inputs only if output contains an
+				// image
+				if (containsImage()) getDatasets(browse, ctx, user, images, datasets);
 
 				// attach specified outputs to inputs
 				attachOutputs(datasets, ctx, browse, images);
@@ -382,8 +386,8 @@ public class ModuleAdapter extends AbstractContextual {
 	private ExperimenterData createUser() {
 		final LoginCredentials cred = new LoginCredentials();
 		cred.getServer().setHostname(client.getProperty("omero.host"));
-		cred.getServer()
-		.setPort(Integer.parseInt(client.getProperty("omero.port")));
+		cred.getServer().setPort(Integer.parseInt(client.getProperty(
+			"omero.port")));
 		cred.getUser().setUsername(client.getProperty("omero.user"));
 		cred.getUser().setPassword(client.getProperty("omero.pass"));
 
@@ -402,11 +406,13 @@ public class ModuleAdapter extends AbstractContextual {
 	 * with those IDs.
 	 *
 	 * @throws ServerError
+	 * @throws DSAccessException
+	 * @throws DSOutOfServiceException
 	 */
 	private ArrayList<ImageData> getInputImages(final BrowseFacility browse,
 		final SecurityContext ctx, final ArrayList<ImageData> images)
-				throws ServerError
-				{
+		throws ServerError, DSOutOfServiceException, DSAccessException
+	{
 		for (final String name : client.getInputKeys()) {
 			final Object value = client.getInput(name);
 			if (!(value instanceof RLong)) continue;
@@ -414,25 +420,29 @@ public class ModuleAdapter extends AbstractContextual {
 			try {
 				images.add(browse.getImage(ctx, imageID));
 			}
-			catch(NoSuchElementException err) {
+			catch (final NoSuchElementException err) {
 				log.error("ImageID: " + imageID + " is not valid");
-				return new ArrayList<ImageData>();
+				return new ArrayList<>();
 			}
 		}
 		return images;
-				}
+	}
 
 	/**
 	 * Retrieves all the datasets associated with this user, and then loops over
 	 * these datasets and their respective images looking for datasets which
 	 * contain the input images. Then it returns a list of these OMERO datasets.
+	 * 
+	 * @throws DSAccessException
+	 * @throws DSOutOfServiceException
 	 */
 	private ArrayList<DatasetData> getDatasets(final BrowseFacility browse,
 		final SecurityContext ctx, final ExperimenterData user,
 		final ArrayList<ImageData> images, final ArrayList<DatasetData> finalIDs)
-		{
-		final Collection<DatasetData> dataSetIDs =
-				browse.getDatasets(ctx, user.getId());
+		throws DSOutOfServiceException, DSAccessException
+	{
+		final Collection<DatasetData> dataSetIDs = browse.getDatasets(ctx, user
+			.getId());
 
 		for (final DatasetData dataset : dataSetIDs) {
 			@SuppressWarnings("unchecked")
@@ -444,7 +454,7 @@ public class ModuleAdapter extends AbstractContextual {
 			}
 		}
 		return finalIDs;
-		}
+	}
 
 	/**
 	 * Loops over outputs and attaches them to appropriate OMERO objects when
@@ -453,18 +463,19 @@ public class ModuleAdapter extends AbstractContextual {
 	 * @throws ServerError
 	 */
 	private void attachOutputs(final ArrayList<DatasetData> datasets,
-		final SecurityContext ctx, final BrowseFacility browse, final
-		ArrayList<ImageData> images) throws ServerError
+		final SecurityContext ctx, final BrowseFacility browse,
+		final ArrayList<ImageData> images) throws ServerError
 	{
 		for (final String key : client.getOutputKeys()) {
-			omero.RType output = client.getOutput(key);
+			final omero.RType output = client.getOutput(key);
 			if (!(output instanceof RLong)) continue;
 			final long id = ((RLong) output).getValue();
-			if(key.contains("table")) {
+			if (key.contains("table")) {
 				attachTableToImages(id, images, ctx);
 			}
 			else {
-				if(!datasets.isEmpty()) attachImageToDataset(id, datasets, ctx, browse);
+				if (!datasets.isEmpty()) attachImageToDataset(id, datasets, ctx,
+					browse);
 			}
 		}
 	}
@@ -477,8 +488,8 @@ public class ModuleAdapter extends AbstractContextual {
 		final BrowseFacility browse)
 	{
 		try {
-			final DataManagerFacility dm =
-					gateway.getFacility(DataManagerFacility.class);
+			final DataManagerFacility dm = gateway.getFacility(
+				DataManagerFacility.class);
 			final ImageData image = browse.getImage(ctx, imageID);
 			for (final DatasetData dset : datasets)
 				dm.addImageToDataset(ctx, image, dset);
@@ -499,8 +510,9 @@ public class ModuleAdapter extends AbstractContextual {
 	/**
 	 * Attaches a table to OMERO images(s).
 	 */
-	private void attachTableToImages(final long tableID, final
-		ArrayList<ImageData> images, final SecurityContext ctx) {
+	private void attachTableToImages(final long tableID,
+		final ArrayList<ImageData> images, final SecurityContext ctx)
+	{
 
 		final OriginalFile tableFile = new OriginalFileI(tableID, false);
 		DataManagerFacility dm;
@@ -509,12 +521,12 @@ public class ModuleAdapter extends AbstractContextual {
 
 			FileAnnotation annotation = new FileAnnotationI();
 			// TODO assign annotation to a table namespace
-			annotation.setNs(omero.rtypes
-				.rstring(omero.constants.namespaces.NSBULKANNOTATIONS.value));
+			annotation.setNs(omero.rtypes.rstring(
+				omero.constants.namespaces.NSBULKANNOTATIONS.value));
 			annotation.setFile(tableFile);
 			annotation = (FileAnnotation) dm.saveAndReturnObject(ctx, annotation);
 
-			for(ImageData i : images) {
+			for (final ImageData i : images) {
 				ImageAnnotationLink link = new ImageAnnotationLinkI();
 				link.setChild(annotation);
 				link.setParent(i.asImage());
@@ -522,14 +534,14 @@ public class ModuleAdapter extends AbstractContextual {
 				link = (ImageAnnotationLink) dm.saveAndReturnObject(ctx, link);
 			}
 		}
-		catch (ExecutionException exc) {
+		catch (final ExecutionException exc) {
 			log.error("Cannot create DataManagerFacility");
 		}
-		catch (DSOutOfServiceException exc) {
+		catch (final DSOutOfServiceException exc) {
 			log.error("Cannot attach table to image. TableID: " + tableID +
 				" Image(s): " + images.toString());
 		}
-		catch (DSAccessException exc) {
+		catch (final DSAccessException exc) {
 			log.error("Cannot attach table to image. TableID: " + tableID +
 				" Image(s): " + images.toString());
 		}
@@ -538,7 +550,7 @@ public class ModuleAdapter extends AbstractContextual {
 	/** Checks if the output contains an image */
 	private boolean containsImage() throws ServerError {
 		for (final String key : client.getOutputKeys()) {
-			omero.RType output = client.getOutput(key);
+			final omero.RType output = client.getOutput(key);
 			if (output instanceof RLong && !key.contains("table")) return true;
 		}
 		return false;

--- a/src/main/java/net/imagej/omero/ModuleAdapter.java
+++ b/src/main/java/net/imagej/omero/ModuleAdapter.java
@@ -187,8 +187,8 @@ public class ModuleAdapter extends AbstractContextual {
 		// populate outputs
 		log.debug(info.getTitle() + ": populating outputs");
 		for (final ModuleItem<?> item : module.getInfo().outputs()) {
-			final omero.RType value = omeroService.toOMERO(client, item.getValue(
-				module));
+			final omero.RType value = (omero.RType) omeroService.toOMERO(client, item
+				.getValue(module));
 			final String name = getOutputName(item);
 			if (value == null) {
 				log.warn(info.getTitle() + ": output '" + name + "' is null");

--- a/src/main/java/net/imagej/omero/OMEROFormat.java
+++ b/src/main/java/net/imagej/omero/OMEROFormat.java
@@ -596,7 +596,7 @@ public class OMEROFormat extends AbstractFormat {
 			try {
 				final Gateway gateway = session.getGateway();
 				final ExperimenterData user = session.getExperimenter();
-				final SecurityContext ctx = new SecurityContext(user.getGroupId());
+				final SecurityContext ctx = session.getSecurityContext();
 				final BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
 				final DataManagerFacility dmf =
 						gateway.getFacility(DataManagerFacility.class);

--- a/src/main/java/net/imagej/omero/OMEROFormat.java
+++ b/src/main/java/net/imagej/omero/OMEROFormat.java
@@ -45,7 +45,10 @@ import io.scif.io.RandomAccessInputStream;
 import io.scif.util.FormatTools;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
@@ -55,6 +58,15 @@ import net.imagej.axis.LinearAxis;
 import omero.RInt;
 import omero.ServerError;
 import omero.api.RawPixelsStorePrx;
+import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.facility.BrowseFacility;
+import omero.gateway.facility.DataManagerFacility;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.ExperimenterData;
+import omero.gateway.model.ImageData;
 import omero.model.Image;
 import omero.model.Length;
 import omero.model.Pixels;
@@ -109,6 +121,9 @@ public class OMEROFormat extends AbstractFormat {
 
 		@Field
 		private String name;
+
+		@Field
+		private long datasetID;
 
 		@Field(label = "Image ID")
 		private long imageID;
@@ -166,6 +181,10 @@ public class OMEROFormat extends AbstractFormat {
 
 		public String getName() {
 			return name;
+		}
+
+		public long getDatasetID() {
+			return datasetID;
 		}
 
 		public long getImageID() {
@@ -529,6 +548,13 @@ public class OMEROFormat extends AbstractFormat {
 					// store resultant image ID into the metadata
 					final Image image = store.save().getImage();
 					getMetadata().setImageID(image.getId().getValue());
+
+					// try to attach image to dataset
+					if (session.getExperimenter() != null && session.getGateway() 
+							!= null && getMetadata().getDatasetID() != 0) {
+						attachImageToDataset(image, getMetadata().getDatasetID());
+					}
+
 					store.close();
 				}
 				catch (final ServerError err) {
@@ -559,6 +585,41 @@ public class OMEROFormat extends AbstractFormat {
 			}
 			catch (final ServerError err) {
 				throw communicationException(err);
+			}
+		}
+
+		/**
+		 * Attaches an image to an OMERO dataset.
+		 */
+		private void attachImageToDataset(Image image, long datasetID)
+		{
+			try {
+				final Gateway gateway = session.getGateway();
+				final ExperimenterData user = session.getExperimenter();
+				final SecurityContext ctx = new SecurityContext(user.getGroupId());
+				final BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
+				final DataManagerFacility dmf =
+						gateway.getFacility(DataManagerFacility.class);
+
+				final ArrayList<Long> collect = new ArrayList<Long>();
+				collect.add(datasetID);
+				final Collection<DatasetData> temp = browse.getDatasets(ctx, collect);
+
+				if (!temp.isEmpty()) {
+					final DatasetData ds = temp.iterator().next();
+					final ImageData imgdata =
+							browse.getImage(ctx, image.getId().getValue());
+					dmf.addImageToDataset(ctx, imgdata, ds);
+				}
+			}
+			catch (final ExecutionException err) {
+				log().error("Error creating Facility", err);
+			}
+			catch (final DSAccessException err) {
+				log().error("Error attaching image to OMERO dataset", err);
+			}
+			catch (final DSOutOfServiceException err) {
+				log().error("Error attaching image to OMERO dataset", err);
 			}
 		}
 

--- a/src/main/java/net/imagej/omero/OMEROFormat.java
+++ b/src/main/java/net/imagej/omero/OMEROFormat.java
@@ -25,8 +25,6 @@
 
 package net.imagej.omero;
 
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
 import io.scif.AbstractChecker;
 import io.scif.AbstractFormat;
 import io.scif.AbstractMetadata;
@@ -55,6 +53,14 @@ import net.imagej.axis.AxisType;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imagej.axis.LinearAxis;
+
+import org.scijava.Priority;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
 import omero.RInt;
 import omero.ServerError;
 import omero.api.RawPixelsStorePrx;
@@ -65,7 +71,6 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.facility.BrowseFacility;
 import omero.gateway.facility.DataManagerFacility;
 import omero.gateway.model.DatasetData;
-import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.ImageData;
 import omero.model.Image;
 import omero.model.Length;
@@ -73,11 +78,6 @@ import omero.model.Pixels;
 import omero.model.Time;
 import omero.model.enums.UnitsLength;
 import omero.model.enums.UnitsTime;
-
-import org.scijava.Priority;
-import org.scijava.log.LogService;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
 
 /**
  * A SCIFIO {@link Format} which provides read/write access to pixels on an
@@ -595,7 +595,6 @@ public class OMEROFormat extends AbstractFormat {
 		{
 			try {
 				final Gateway gateway = session.getGateway();
-				final ExperimenterData user = session.getExperimenter();
 				final SecurityContext ctx = session.getSecurityContext();
 				final BrowseFacility browse = gateway.getFacility(BrowseFacility.class);
 				final DataManagerFacility dmf =

--- a/src/main/java/net/imagej/omero/OMEROFormat.java
+++ b/src/main/java/net/imagej/omero/OMEROFormat.java
@@ -477,7 +477,7 @@ public class OMEROFormat extends AbstractFormat {
 
 		@Override
 		public void close() {
-			if (session != null) session.close();
+			if (session != null) ((DefaultOMEROSession) session).close();
 			session = null;
 			store = null;
 		}
@@ -562,7 +562,7 @@ public class OMEROFormat extends AbstractFormat {
 				}
 			}
 			store = null;
-			if (session != null) session.close();
+			if (session != null) ((DefaultOMEROSession) session).close();
 			session = null;
 		}
 
@@ -692,7 +692,7 @@ public class OMEROFormat extends AbstractFormat {
 		throws FormatException
 	{
 		try {
-			return new OMEROSession(meta.getCredentials());
+			return new DefaultOMEROSession(meta.getCredentials());
 		}
 		catch (final ServerError err) {
 			throw communicationException(err);

--- a/src/main/java/net/imagej/omero/OMERORef.java
+++ b/src/main/java/net/imagej/omero/OMERORef.java
@@ -1,0 +1,30 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+public enum OMERORef {
+	FILE, IMAGE, ROI, WELL, PLATE, PROJECT, DATASET
+}

--- a/src/main/java/net/imagej/omero/OMERORefColumn.java
+++ b/src/main/java/net/imagej/omero/OMERORefColumn.java
@@ -27,9 +27,22 @@ package net.imagej.omero;
 
 import net.imagej.table.LongColumn;
 
+import omero.gateway.facility.TablesFacility;
+
+/**
+ * Wrapper for OMERO reference columns (i.e. FileColumn, ImageColumn, RoiColumn,
+ * etc.). These columns contain long IDs which reference OMERO Data objects.
+ * <p>
+ * Note, when the {@link TablesFacility} gets a Table it does create DataObjects
+ * but does not actually load them.
+ * </p>
+ *
+ * @author Alison Walter
+ */
 public class OMERORefColumn extends LongColumn {
 
 	private final OMERORef ref;
+	private Object[] originalData;
 
 	public OMERORefColumn(final OMERORef referenceType) {
 		super();
@@ -43,6 +56,14 @@ public class OMERORefColumn extends LongColumn {
 
 	public OMERORef getOMERORef() {
 		return ref;
+	}
+
+	public Object[] getOriginalData() {
+		return originalData;
+	}
+
+	public void setOriginalData(final Object[] data) {
+		originalData = data;
 	}
 
 }

--- a/src/main/java/net/imagej/omero/OMERORefColumn.java
+++ b/src/main/java/net/imagej/omero/OMERORefColumn.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import net.imagej.table.LongColumn;
+
+public class OMERORefColumn extends LongColumn {
+
+	private final OMERORef ref;
+
+	public OMERORefColumn(final OMERORef referenceType) {
+		super();
+		ref = referenceType;
+	}
+
+	public OMERORefColumn(final String header, final OMERORef referenceType) {
+		super(header);
+		ref = referenceType;
+	}
+
+	public OMERORef getOMERORef() {
+		return ref;
+	}
+
+}

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -25,9 +25,6 @@
 
 package net.imagej.omero;
 
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
@@ -36,11 +33,15 @@ import net.imagej.ImageJService;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
 import net.imagej.table.Table;
+
+import org.scijava.module.ModuleItem;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
 import omero.ServerError;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
-
-import org.scijava.module.ModuleItem;
+import omero.gateway.model.TableData;
 
 /**
  * Interface for ImageJ services that manage OMERO data conversion.
@@ -72,13 +73,16 @@ public interface OMEROService extends ImageJService {
 	 * method will be used transparently to convert the object into an OMERO image
 	 * ID.
 	 * </p>
+	 * <p>
+	 * In the case of {@link Table}s, it will be converted to a {@link TableData}.
+	 * </p>
 	 * @throws DSAccessException
 	 * @throws DSOutOfServiceException
 	 * @throws ExecutionException
 	 * @throws CannotCreateSessionException
 	 * @throws PermissionDeniedException
 	 */
-	omero.RType toOMERO(omero.client client, Object value)
+	Object toOMERO(omero.client client, Object value)
 		throws omero.ServerError, IOException, PermissionDeniedException,
 		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
 		DSAccessException;
@@ -112,12 +116,18 @@ public interface OMEROService extends ImageJService {
 
 	/**
 	 * Uploads an ImageJ table to OMERO, returning the new table ID on the OMERO
-	 * server.
+	 * server. Tables must be attached to a DataObject, thus the given image ID
+	 * must be valid or this method will throw an exception.
 	 */
 	long uploadTable(OMEROCredentials credentials, String name,
 		Table<?, ?> imageJTable, final long imageID) throws ServerError,
 		PermissionDeniedException, CannotCreateSessionException,
 		ExecutionException, DSOutOfServiceException, DSAccessException;
+
+	/** Converts the given ImageJ table to an OMERO table, but does not save the
+	 * table to the server.
+	 */
+	TableData convertOMEROTable(Table<?, ?> imageJTable);
 
 	/**
 	 * Downloads the table with the given ID from OMERO, storing the result into a

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -29,14 +29,16 @@ import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJService;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
-import net.imagej.table.Column;
 import net.imagej.table.Table;
 import omero.ServerError;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
 
 import org.scijava.module.ModuleItem;
 
@@ -104,8 +106,9 @@ public interface OMEROService extends ImageJService {
 	 * server.
 	 */
 	long uploadTable(OMEROCredentials credentials, String name,
-		Table<?, ?> imageJTable) throws ServerError, PermissionDeniedException,
-		CannotCreateSessionException;
+		Table<?, ?> imageJTable, final long imageID) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException;
 
 	/**
 	 * Downloads the table with the given ID from OMERO, storing the result into a

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -72,9 +72,16 @@ public interface OMEROService extends ImageJService {
 	 * method will be used transparently to convert the object into an OMERO image
 	 * ID.
 	 * </p>
+	 * @throws DSAccessException
+	 * @throws DSOutOfServiceException
+	 * @throws ExecutionException
+	 * @throws CannotCreateSessionException
+	 * @throws PermissionDeniedException
 	 */
 	omero.RType toOMERO(omero.client client, Object value)
-		throws omero.ServerError, IOException;
+		throws omero.ServerError, IOException, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException;
 
 	/**
 	 * Converts an OMERO parameter value to an ImageJ value of the given type.
@@ -85,7 +92,8 @@ public interface OMEROService extends ImageJService {
 	 * OMERO image ID into such an object.
 	 */
 	Object toImageJ(omero.client client, omero.RType value, Class<?> type)
-		throws omero.ServerError, IOException;
+		throws omero.ServerError, IOException, PermissionDeniedException,
+		CannotCreateSessionException;
 
 	/**
 	 * Downloads the image with the given image ID from OMERO, storing the result

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -107,4 +107,11 @@ public interface OMEROService extends ImageJService {
 		Table<?, ?> imageJTable) throws ServerError, PermissionDeniedException,
 		CannotCreateSessionException;
 
+	/**
+	 * Downloads the table with the given ID from OMERO, storing the result into a
+	 * new ImageJ {@link Table}.
+	 */
+	Table<?, ?> downloadTable(OMEROCredentials credentials, long tableID)
+		throws ServerError, PermissionDeniedException, CannotCreateSessionException;
+
 }

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -93,7 +93,7 @@ public interface OMEROService extends ImageJService {
 	 */
 	Object toImageJ(omero.client client, omero.RType value, Class<?> type)
 		throws omero.ServerError, IOException, PermissionDeniedException,
-		CannotCreateSessionException;
+		CannotCreateSessionException, DSOutOfServiceException;
 
 	/**
 	 * Downloads the image with the given image ID from OMERO, storing the result
@@ -123,6 +123,7 @@ public interface OMEROService extends ImageJService {
 	 * new ImageJ {@link Table}.
 	 */
 	Table<?, ?> downloadTable(OMEROCredentials credentials, long tableID)
-		throws ServerError, PermissionDeniedException, CannotCreateSessionException;
+		throws ServerError, PermissionDeniedException, CannotCreateSessionException,
+		DSOutOfServiceException;
 
 }

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -25,12 +25,18 @@
 
 package net.imagej.omero;
 
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+
 import java.io.IOException;
 
 import net.imagej.Dataset;
 import net.imagej.ImageJService;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+import omero.ServerError;
 
 import org.scijava.module.ModuleItem;
 
@@ -92,5 +98,13 @@ public interface OMEROService extends ImageJService {
 	 */
 	long uploadImage(omero.client client, Dataset dataset)
 		throws omero.ServerError, IOException;
+
+	/**
+	 * Uploads an ImageJ table to OMERO, returning the new table ID on the OMERO
+	 * server.
+	 */
+	long uploadTable(OMEROCredentials credentials, String name,
+		Table<?, ?> imageJTable) throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException;
 
 }

--- a/src/main/java/net/imagej/omero/OMEROService.java
+++ b/src/main/java/net/imagej/omero/OMEROService.java
@@ -93,7 +93,8 @@ public interface OMEROService extends ImageJService {
 	 */
 	Object toImageJ(omero.client client, omero.RType value, Class<?> type)
 		throws omero.ServerError, IOException, PermissionDeniedException,
-		CannotCreateSessionException, DSOutOfServiceException;
+		CannotCreateSessionException, SecurityException, DSOutOfServiceException,
+		ExecutionException, DSAccessException;
 
 	/**
 	 * Downloads the image with the given image ID from OMERO, storing the result
@@ -124,6 +125,6 @@ public interface OMEROService extends ImageJService {
 	 */
 	Table<?, ?> downloadTable(OMEROCredentials credentials, long tableID)
 		throws ServerError, PermissionDeniedException, CannotCreateSessionException,
-		DSOutOfServiceException;
+		ExecutionException, DSOutOfServiceException, DSAccessException;
 
 }

--- a/src/main/java/net/imagej/omero/OMEROSession.java
+++ b/src/main/java/net/imagej/omero/OMEROSession.java
@@ -25,13 +25,15 @@
 
 package net.imagej.omero;
 
+import io.scif.FormatException;
+
 import java.io.Closeable;
 
-import io.scif.FormatException;
 import omero.ServerError;
 import omero.api.RawPixelsStorePrx;
 import omero.api.ServiceFactoryPrx;
 import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
 import omero.gateway.model.ExperimenterData;
 import omero.model.Image;
 import omero.model.Pixels;
@@ -43,6 +45,9 @@ public interface OMEROSession extends Closeable {
 
 	/** Gets the {@code ServiceFactoryPrx} associated with this OMEROSession */
 	ServiceFactoryPrx getSession();
+
+	/** Gets the {@code SecurityContext} associated with this OMEROSession */
+	SecurityContext getSecurityContext();
 
 	/** Gets the {@code Experimenter} associated with this OMEROSession */
 	ExperimenterData getExperimenter();

--- a/src/main/java/net/imagej/omero/OMEROSession.java
+++ b/src/main/java/net/imagej/omero/OMEROSession.java
@@ -9,15 +9,15 @@
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the 
+ * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public 
+ *
+ * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
@@ -25,339 +25,54 @@
 
 package net.imagej.omero;
 
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
-import io.scif.FormatException;
-import io.scif.ImageMetadata;
-import io.scif.util.FormatTools;
-
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
 
-import net.imagej.axis.Axes;
-import net.imagej.axis.AxisType;
-import omero.RLong;
+import io.scif.FormatException;
 import omero.ServerError;
 import omero.api.RawPixelsStorePrx;
 import omero.api.ServiceFactoryPrx;
 import omero.gateway.Gateway;
-import omero.gateway.LoginCredentials;
-import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.ExperimenterData;
-import omero.gateway.model.ImageData;
-import omero.log.Logger;
-import omero.log.SimpleLogger;
-import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Pixels;
-import omero.model.PixelsType;
 
-/**
- * Helper class for managing OMERO client sessions.
- * 
- * @author Curtis Rueden
- */
-public class OMEROSession implements Closeable {
+public interface OMEROSession extends Closeable {
 
-	// -- Fields --
+	/** Gets the {@code omero.client} associated with this OMEROSession */
+	omero.client getClient();
 
-	private omero.client client;
-	private ServiceFactoryPrx session;
-	private ExperimenterData experimenter;
-	private Gateway gateway;
+	/** Gets the {@code ServiceFactoryPrx} associated with this OMEROSession */
+	ServiceFactoryPrx getSession();
 
-	// -- Constructors --
+	/** Gets the {@code Experimenter} associated with this OMEROSession */
+	ExperimenterData getExperimenter();
 
-	public OMEROSession(final OMEROCredentials credentials) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException
-	{
-		this(credentials, null);
-	}
-
-	public OMEROSession(final OMEROCredentials credentials, final omero.client c)
-		throws ServerError, PermissionDeniedException, CannotCreateSessionException
-	{
-		// initialize the client
-		boolean close = false;
-		if (c == null) {
-			final String server = credentials.getServer();
-			if (server != null) {
-				client = new omero.client(server, credentials.getPort());
-			}
-			else client = new omero.client();
-		}
-		else {
-			client = c;
-			close = true;
-		}
-
-		// initialize the session (i.e., log in)
-		final String sessionID = credentials.getSessionID();
-		if (sessionID != null) {
-			if (close) client.closeSession();
-			session = client.joinSession(sessionID);
-		}
-		else if (credentials.getUser() != null && credentials.getPassword() != null)
-		{
-			final String user = credentials.getUser();
-			final String password = credentials.getPassword();
-			setGateway();
-			setExperimenter(credentials);
-			session = client.createSession(user, password);
-			credentials.setSessionID(client.getSessionId());
-		}
-		else {
-			session = client.createSession();
-		}
-
-		// Until imagej-omero #30 is resolved; see:
-		// https://github.com/imagej/imagej-omero/issues/30
-//		if (client.isSecure() && !credentials.isEncrypted()) {
-//			client = client.createClient(false);
-//			session = client.getSession();
-//		}
-
-		session.detachOnDestroy();
-	}
-
-	// -- OMEROSession methods --
-
-	public omero.client getClient() {
-		return client;
-	}
-
-	public ServiceFactoryPrx getSession() {
-		return session;
-	}
-
-	public ExperimenterData getExperimenter() {
-		return this.experimenter;
-	}
-
-	public Gateway getGateway() {
-		return this.gateway;
-	}
+	/** Gets the {@code Gateway} associated with this OMEROSession */
+	Gateway getGateway();
 
 	/** Gets an OMERO {@code Pixels} descriptor, loading remotely as needed. */
-	public Pixels loadPixels(final OMEROFormat.Metadata meta) throws ServerError {
-		// return cached Pixels if available
-		Pixels pixels = meta.getPixels();
-		if (pixels != null) return pixels;
-
-		// NB: We cannot write:
-		//
-		// loadImage(meta).getPixels(0)
-		//
-		// because retrieving an Image is not enough to
-		// retrieve all fields of the linked Pixels.
-
-		// load the pixels ID from the remote server
-		final long pixelsID = loadPixelsID(meta);
-		meta.setPixelsID(pixelsID);
-
-		// load the Pixels from the remote server
-		pixels = session.getPixelsService().retrievePixDescription(pixelsID);
-		meta.setPixels(pixels);
-
-		return pixels;
-	}
+	Pixels loadPixels(OMEROFormat.Metadata meta) throws ServerError;
 
 	/** Gets an OMERO {@code Image} descriptor, loading remotely as needed. */
-	public Image loadImage(final OMEROFormat.Metadata meta) throws ServerError {
-		// return cached Image if available
-		Image image = meta.getImage();
-		if (image != null) return image;
-
-		final long imageID = meta.getImageID();
-		if (imageID == 0) throw new IllegalArgumentException("Image ID is unset");
-
-		// load the Image from the remote server
-		final List<Long> ids = Arrays.asList(imageID);
-		final List<Image> images =
-			session.getContainerService().getImages("Image", ids, null);
-		if (images == null || images.isEmpty()) {
-			throw new IllegalArgumentException("Invalid image ID: " + imageID);
-		}
-		image = images.get(0);
-		meta.setImage(image);
-
-		return image;
-	}
+	Image loadImage(OMEROFormat.Metadata meta) throws ServerError;
 
 	/** Gets the metadata's associated pixels ID, loading remotely as needed. */
-	public long loadPixelsID(final OMEROFormat.Metadata meta) throws ServerError {
-		// return cached pixels ID if available
-		long pixelsID = meta.getPixelsID();
-		if (pixelsID != 0) return pixelsID;
-
-		// obtain pixels ID from image ID
-		pixelsID = loadImage(meta).getPixels(0).getId().getValue();
-		meta.setPixelsID(pixelsID);
-
-		return pixelsID;
-	}
+	long loadPixelsID(OMEROFormat.Metadata meta) throws ServerError;
 
 	/** Gets the metadata's associated image name, loading remotely as needed. */
-	public String loadImageName(final OMEROFormat.Metadata meta)
-		throws ServerError
-	{
-		// return cached image name if available
-		String name = meta.getName();
-		if (name != null) return name;
-
-		// load the Image name from the remote server
-		name = loadImage(meta).getName().getValue();
-		meta.setName(name);
-
-		return name;
-	}
+	String loadImageName(OMEROFormat.Metadata meta) throws ServerError;
 
 	/**
 	 * Obtains a raw pixels store for reading from the pixels associated with the
 	 * given metadata.
 	 */
-	public RawPixelsStorePrx openPixels(final OMEROFormat.Metadata meta)
-		throws ServerError
-	{
-		final RawPixelsStorePrx store = session.createRawPixelsStore();
-		store.setPixelsId(loadPixelsID(meta), false);
-		return store;
-	}
+	RawPixelsStorePrx openPixels(OMEROFormat.Metadata meta) throws ServerError;
 
 	/**
 	 * Obtains a raw pixels store for writing to a new image which will be
 	 * associated with the given metadata.
 	 */
-	public RawPixelsStorePrx createPixels(final OMEROFormat.Metadata meta)
-		throws ServerError, FormatException
-	{
-		// create a new Image which will house the written pixels
-		final ImageData newImage = createImage(meta);
-		final long imageID = newImage.getId();
-		meta.setImageID(imageID);
-
-		// configure the raw pixels store
-		final RawPixelsStorePrx store = session.createRawPixelsStore();
-		final long pixelsID = newImage.getDefaultPixels().getId();
-		store.setPixelsId(pixelsID, false);
-		meta.setPixelsID(pixelsID);
-
-		return store;
-	}
-
-	// -- Closeable methods --
-
-	@Override
-	public void close() {
-		if (client != null) client.__del__();
-		client = null;
-		session = null;
-		if (gateway != null) gateway.disconnect();
-	}
-
-	// -- Helper methods --
-
-	private ImageData createImage(final OMEROFormat.Metadata meta)
-		throws ServerError, FormatException
-	{
-		// create a new Image
-		final ImageMetadata imageMeta = meta.get(0);
-		final int xLen = axisLength(imageMeta, Axes.X);
-		final int yLen = axisLength(imageMeta, Axes.Y);
-		final int zLen = axisLength(imageMeta, Axes.Z);
-		final int tLen = axisLength(imageMeta, Axes.TIME);
-		final int cLen = axisLength(imageMeta, Axes.CHANNEL);
-		final int sizeX = xLen == 0 ? 1 : xLen;
-		final int sizeY = yLen == 0 ? 1 : yLen;
-		final int sizeZ = zLen == 0 ? 1 : zLen;
-		final int sizeT = tLen == 0 ? 1 : tLen;
-		final int sizeC = cLen == 0 ? 1 : cLen;
-		final List<Integer> channelList = new ArrayList<Integer>(sizeC);
-		for (int c = 0; c < sizeC; c++) {
-			// TODO: Populate actual emission wavelengths?
-			channelList.add(c);
-		}
-		final int pixelType = imageMeta.getPixelType();
-		final PixelsType pixelsType = getPixelsType(pixelType);
-		final String name = meta.getName();
-		final String description = meta.getName();
-		final RLong id =
-			session.getPixelsService().createImage(sizeX, sizeY, sizeZ, sizeT,
-				channelList, pixelsType, name, description);
-		if (id == null) throw new FormatException("Cannot create image");
-
-		// retrieve the newly created Image
-		final List<Image> results =
-			session.getContainerService().getImages(Image.class.getName(),
-				Arrays.asList(id.getValue()), null);
-		return new ImageData(results.get(0));
-	}
-
-	private PixelsType getPixelsType(final int pixelType) throws ServerError,
-		FormatException
-	{
-		return getPixelsType(FormatTools.getPixelTypeString(pixelType));
-	}
-
-	private PixelsType getPixelsType(final String pixelType) throws ServerError,
-		FormatException
-	{
-		final List<IObject> list =
-			session.getPixelsService().getAllEnumerations(PixelsType.class.getName());
-		final Iterator<IObject> iter = list.iterator();
-		while (iter.hasNext()) {
-			final PixelsType type = (PixelsType) iter.next();
-			final String value = type.getValue().getValue();
-			if (value.equals(pixelType)) return type;
-		}
-		throw new FormatException("Invalid pixel type: " + pixelType);
-	}
-
-	private int
-		axisLength(final ImageMetadata imageMeta, final AxisType axisType)
-			throws FormatException
-	{
-		final long axisLength = imageMeta.getAxisLength(axisType);
-		if (axisLength > Integer.MAX_VALUE) {
-			throw new FormatException("Length of " + axisType +
-				" axis is too large for OMERO: " + axisLength);
-		}
-		return (int) axisLength;
-	}
-
-	/**
-	 * Attempts to connect to the gateway using the given credentials. If it can
-	 * successfully connect, then it sets experimenter. 
-	 */
-	private void setExperimenter(OMEROCredentials credentials) throws ServerError
-	{
-		final LoginCredentials cred = new LoginCredentials();
-		cred.getServer().setHostname(credentials.getServer());
-		cred.getServer().setPort(credentials.getPort());
-		cred.getUser().setUsername(credentials.getUser());
-		cred.getUser().setPassword(credentials.getPassword());
-
-		if(this.gateway == null) setGateway();
-
-		try {
-			this.experimenter = this.gateway.connect(cred);
-		}
-		catch (DSOutOfServiceException exc) {
-			final ServerError err = new ServerError();
-			err.initCause(exc);
-			throw err;
-		}
-	}
-
-	/**
-	 * Creates a new gateway for the session.
-	 */
-	private void setGateway() {
-		final Logger simpleLogger = new SimpleLogger();
-		this.gateway = new Gateway(simpleLogger);
-	}
+	RawPixelsStorePrx createPixels(OMEROFormat.Metadata meta) throws ServerError,
+		FormatException;
 
 }

--- a/src/main/java/net/imagej/omero/OMEROSession.java
+++ b/src/main/java/net/imagej/omero/OMEROSession.java
@@ -75,4 +75,9 @@ public interface OMEROSession extends Closeable {
 	RawPixelsStorePrx createPixels(OMEROFormat.Metadata meta) throws ServerError,
 		FormatException;
 
+	// -- Closeable methods --
+
+	@Override
+	void close();
+
 }

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -57,7 +57,7 @@ import org.scijava.util.ShortArray;
 
 /**
  * Utility class for working with converting between ImageJ and OMERO tables.
- * 
+ *
  * @author Curtis Rueden
  */
 public final class TableUtils {
@@ -123,49 +123,55 @@ public final class TableUtils {
 		final omero.grid.Column omeroColumn)
 	{
 		final Class<?> type = imageJColumn.getType();
+		final int s = imageJColumn.size();
 		if (OMERORefColumn.class.isInstance(imageJColumn)) {
 			populateOMERORefColumn(((OMERORefColumn) imageJColumn).getOMERORef(),
-				((OMERORefColumn) imageJColumn).getArray(), omeroColumn);
+				((OMERORefColumn) imageJColumn).getArray(), omeroColumn, s);
 		}
 		else if (type == Double.class) {
 			final DoubleColumn doubleColumn = (DoubleColumn) imageJColumn;
 			final omero.grid.DoubleColumn omeroDColumn =
 				(omero.grid.DoubleColumn) omeroColumn;
-			omeroDColumn.values = doubleColumn.getArray();
+			omeroDColumn.values = new double[s];
+			System.arraycopy(doubleColumn.getArray(), 0, omeroDColumn.values, 0, s);
 		}
 		else if (type == Float.class) {
 			final omero.grid.DoubleColumn omeroDColumn =
 				(omero.grid.DoubleColumn) omeroColumn;
 			omeroDColumn.values =
-					toDoubleArray(((FloatColumn) imageJColumn).getArray());
+				toDoubleArray(((FloatColumn) imageJColumn).getArray(), s);
 		}
 		else if (type == Boolean.class) {
 			final BoolColumn boolColumn = (BoolColumn) imageJColumn;
 			final omero.grid.BoolColumn omeroBColumn =
 				(omero.grid.BoolColumn) omeroColumn;
-			omeroBColumn.values = boolColumn.getArray();
+			omeroBColumn.values = new boolean[s];
+			System.arraycopy(boolColumn.getArray(), 0, omeroBColumn.values, 0, s);
 		}
 		else if (type == Long.class) {
 			final LongColumn longColumn = (LongColumn) imageJColumn;
 			final omero.grid.LongColumn omeroLColumn =
 				(omero.grid.LongColumn) omeroColumn;
-			omeroLColumn.values = longColumn.getArray();
+			omeroLColumn.values = new long[s];
+			System.arraycopy(longColumn.getArray(), 0, omeroLColumn.values, 0, s);
 		}
 		else if (type == Byte.class) {
 			final omero.grid.LongColumn omeroLColumn =
 				(omero.grid.LongColumn) omeroColumn;
-			omeroLColumn.values = toLongArray(((ByteColumn) imageJColumn).getArray());
+			omeroLColumn.values =
+				toLongArray(((ByteColumn) imageJColumn).getArray(), s);
 		}
 		else if (type == Short.class) {
 			final omero.grid.LongColumn omeroLColumn =
 				(omero.grid.LongColumn) omeroColumn;
 			omeroLColumn.values =
-				toLongArray(((ShortColumn) imageJColumn).getArray());
+				toLongArray(((ShortColumn) imageJColumn).getArray(), s);
 		}
 		else if (type == Integer.class) {
 			final omero.grid.LongColumn omeroLColumn =
 				(omero.grid.LongColumn) omeroColumn;
-			omeroLColumn.values = toLongArray(((IntColumn) imageJColumn).getArray());
+			omeroLColumn.values =
+				toLongArray(((IntColumn) imageJColumn).getArray(), s);
 		}
 		else if (type == DoubleArray.class) {
 			final DefaultColumn<DoubleArray> defaultColumn =
@@ -174,7 +180,9 @@ public final class TableUtils {
 				(omero.grid.DoubleArrayColumn) omeroColumn;
 			final double[][] values = new double[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = defaultColumn.get(i).getArray();
+				values[i] = new double[defaultColumn.get(i).size()];
+				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
+					defaultColumn.get(i).size());
 			}
 			omeroDAColumn.values = values;
 		}
@@ -185,7 +193,9 @@ public final class TableUtils {
 				(omero.grid.FloatArrayColumn) omeroColumn;
 			final float[][] values = new float[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = defaultColumn.get(i).getArray();
+				values[i] = new float[defaultColumn.get(i).size()];
+				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
+					defaultColumn.get(i).size());
 			}
 			omeroFAColumn.values = values;
 		}
@@ -196,7 +206,9 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = defaultColumn.get(i).getArray();
+				values[i] = new long[defaultColumn.get(i).size()];
+				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
+					defaultColumn.get(i).size());
 			}
 			omeroLAColumn.values = values;
 		}
@@ -207,7 +219,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = toLongArray(defaultColumn.get(i).getArray());
+				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
 		}
@@ -218,7 +230,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = toLongArray(defaultColumn.get(i).getArray());
+				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
 		}
@@ -229,7 +241,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = toLongArray(defaultColumn.get(i).getArray());
+				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
 		}
@@ -240,7 +252,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
-				values[i] = toLongArray(defaultColumn.get(i).getArray());
+				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
 		}
@@ -249,14 +261,15 @@ public final class TableUtils {
 				(DefaultColumn<String>) imageJColumn;
 			final omero.grid.StringColumn omeroSColumn =
 				(omero.grid.StringColumn) omeroColumn;
-			omeroSColumn.values = defaultColumn.getArray();
+			omeroSColumn.values = new String[s];
+			System.arraycopy(defaultColumn.getArray(), 0, omeroSColumn.values, 0, s);
 		}
 		else if (type == Character.class) {
 			final CharColumn charColumn = (CharColumn) imageJColumn;
 			final omero.grid.StringColumn omeroSColumn =
 				(omero.grid.StringColumn) omeroColumn;
 			final char[] temp = charColumn.getArray();
-			final String[] values = new String[temp.length];
+			final String[] values = new String[s];
 			for (int i = 0; i < values.length; i++) {
 				values[i] = String.valueOf(temp[i]);
 			}
@@ -429,40 +442,40 @@ public final class TableUtils {
 
 	// -- Helper methods --
 
-	private static long[] toLongArray(boolean[] b) {
-		final long[] l = new long[b.length];
+	private static long[] toLongArray(final boolean[] b, final int size) {
+		final long[] l = new long[size];
 		for (int q = 0; q < l.length; q++) {
 			l[q] = b[q] ? 1 : 0;
 		}
 		return l;
 	}
 
-	private static long[] toLongArray(byte[] b) {
-		final long[] l = new long[b.length];
+	private static long[] toLongArray(final byte[] b, final int size) {
+		final long[] l = new long[size];
 		for (int q = 0; q < l.length; q++) {
 			l[q] = b[q];
 		}
 		return l;
 	}
 
-	private static long[] toLongArray(short[] s) {
-		final long[] l = new long[s.length];
+	private static long[] toLongArray(final short[] s, final int size) {
+		final long[] l = new long[size];
 		for (int q = 0; q < l.length; q++) {
 			l[q] = s[q];
 		}
 		return l;
 	}
 
-	private static long[] toLongArray(int[] i) {
-		final long[] l = new long[i.length];
+	private static long[] toLongArray(final int[] i, final int size) {
+		final long[] l = new long[size];
 		for (int q = 0; q < l.length; q++) {
 			l[q] = i[q];
 		}
 		return l;
 	}
 
-	private static double[] toDoubleArray(float[] i) {
-		final double[] d = new double[i.length];
+	private static double[] toDoubleArray(final float[] i, final int size) {
+		final double[] d = new double[size];
 		for (int q = 0; q < d.length; q++) {
 			d[q] = i[q];
 		}
@@ -547,22 +560,24 @@ public final class TableUtils {
 	}
 
 	private static void populateOMERORefColumn(final OMERORef refType,
-		final long[] values, final omero.grid.Column omeroColumn)
+		final long[] values, final omero.grid.Column omeroColumn, final int size)
 	{
+		final long[] ar = new long[size];
+		System.arraycopy(values, 0, ar, 0, size);
 		if (refType == OMERORef.FILE) {
-			((omero.grid.FileColumn) omeroColumn).values = values.clone();
+			((omero.grid.FileColumn) omeroColumn).values = ar.clone();
 		}
 		else if (refType == OMERORef.IMAGE) {
-			((omero.grid.ImageColumn) omeroColumn).values = values.clone();
+			((omero.grid.ImageColumn) omeroColumn).values = ar.clone();
 		}
 		else if (refType == OMERORef.PLATE) {
-			((omero.grid.PlateColumn) omeroColumn).values = values.clone();
+			((omero.grid.PlateColumn) omeroColumn).values = ar.clone();
 		}
 		else if (refType == OMERORef.ROI) {
-			((omero.grid.RoiColumn) omeroColumn).values = values.clone();
+			((omero.grid.RoiColumn) omeroColumn).values = ar.clone();
 		}
 		else if (refType == OMERORef.WELL) {
-			((omero.grid.WellColumn) omeroColumn).values = values.clone();
+			((omero.grid.WellColumn) omeroColumn).values = ar.clone();
 		}
 	}
 }

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -324,6 +324,8 @@ public final class TableUtils {
 				imageJGenericColumn.set(r + offset, Array.get(data, r));
 			}
 		}
+		if (imageJColumn.getHeader() == null) imageJColumn
+			.setHeader(omeroColumn.name);
 	}
 
 	public static Table<?, ?> createImageJTable(

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -91,8 +91,10 @@ public final class TableUtils {
 				(omero.grid.DoubleColumn) omeroColumn;
 			omeroDColumn.values = doubleColumn.getArray();
 		}
-		throw new UnsupportedOperationException("Unsupported column type: " +
-			imageJColumn.getClass().getName());
+		else {
+			throw new UnsupportedOperationException("Unsupported column type: " +
+					imageJColumn.getClass().getName());
+		}
 	}
 
 	public static void populateImageJColumn(final omero.grid.Column omeroColumn,

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -309,8 +309,13 @@ public final class TableUtils {
 			final String[] data = ((omero.grid.StringColumn) omeroColumn).values;
 			final DefaultColumn<String> imageJStringColumn =
 				(DefaultColumn<String>) imageJColumn;
-			System.arraycopy(data, 0, imageJStringColumn.toArray(), offset,
-				data.length);
+			if (imageJStringColumn.getArray() == null) {
+				imageJStringColumn.setArray(data.clone());
+			}
+			else {
+				System.arraycopy(data, 0, imageJStringColumn.getArray(), offset,
+					data.length);
+			}
 		}
 		else {
 			final GenericColumn imageJGenericColumn = (GenericColumn) imageJColumn;

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -25,8 +25,17 @@
 
 package net.imagej.omero;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+
 import net.imagej.table.Column;
+import net.imagej.table.DefaultGenericTable;
+import net.imagej.table.DefaultResultsTable;
 import net.imagej.table.DoubleColumn;
+import net.imagej.table.GenericColumn;
+import net.imagej.table.Table;
+
+import org.scijava.util.ClassUtils;
 
 /**
  * Utility class for working with converting between ImageJ and OMERO tables.
@@ -84,6 +93,97 @@ public final class TableUtils {
 		}
 		throw new UnsupportedOperationException("Unsupported column type: " +
 			imageJColumn.getClass().getName());
+	}
+
+	public static void populateImageJColumn(final omero.grid.Column omeroColumn,
+		final Column<?> imageJColumn, final int offset)
+	{
+		if (omeroColumn instanceof omero.grid.DoubleColumn) {
+			final double[] data = ((omero.grid.DoubleColumn) omeroColumn).values;
+			final DoubleColumn imageJDoubleColumn = (DoubleColumn) imageJColumn;
+			System.arraycopy(data, 0, imageJDoubleColumn.getArray(), offset,
+				data.length);
+		}
+		else {
+			final GenericColumn imageJGenericColumn = (GenericColumn) imageJColumn;
+			final Field field = ClassUtils.getField(omeroColumn.getClass(), "values");
+			final Object data = ClassUtils.getValue(field, omeroColumn);
+			final int length = Array.getLength(data);
+			for (int r = 0; r < length; r++) {
+				imageJGenericColumn.set(r + offset, Array.get(data, r));
+			}
+		}
+	}
+
+	public static Table<?, ?> createImageJTable(
+		final omero.grid.Column[] omeroColumns)
+	{
+		// TODO Decide if we really need this case logic.
+		for (int c = 0; c < omeroColumns.length; c++) {
+			if (!(omeroColumns[c] instanceof omero.grid.DoubleColumn)) {
+				// not all doubles
+				return new DefaultGenericTable();
+			}
+		}
+		// all double columns, yay
+		return new DefaultResultsTable();
+	}
+
+	public static Column<?> createImageJColumn(final omero.grid.Column column) {
+		if (column instanceof omero.grid.BoolColumn) {
+			// TODO: Implement BoolColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.DoubleArrayColumn) {
+			// TODO: Implement DoubleArrayColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.DoubleColumn) {
+			// TODO: Implement DoubleColumn for efficiency.
+			return new DoubleColumn(column.name);
+		}
+		if (column instanceof omero.grid.FileColumn) {
+			// TODO: Implement FileColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.FloatArrayColumn) {
+			// TODO: Implement FloatArrayColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.ImageColumn) {
+			// TODO: Implement ImageColumn for efficiency.
+//		  return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.LongArrayColumn) {
+			// TODO: Implement LongArrayColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.LongColumn) {
+			// TODO: Implement LongColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.MaskColumn) {
+			// TODO: Implement MaskColumn for efficiency.
+//		  return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.PlateColumn) {
+			// TODO: Implement PlateColumn for efficiency.
+//		  return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.RoiColumn) {
+			// TODO: Implement RoiColumn for efficiency.
+//		  return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.StringColumn) {
+			// TODO: Implement StringColumn for efficiency.
+			return new GenericColumn(column.name);
+		}
+		if (column instanceof omero.grid.WellColumn) {
+			// TODO: Implement WellColumn for efficiency.
+//		  return new GenericColumn(column.name);
+		}
+		throw new IllegalArgumentException("Unsupported column type: " +
+			column.getClass().getName());
 	}
 
 }

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -33,8 +33,10 @@ import net.imagej.table.BoolColumn;
 import net.imagej.table.ByteColumn;
 import net.imagej.table.CharColumn;
 import net.imagej.table.Column;
+import net.imagej.table.DefaultBoolTable;
 import net.imagej.table.DefaultColumn;
 import net.imagej.table.DefaultGenericTable;
+import net.imagej.table.DefaultLongTable;
 import net.imagej.table.DefaultResultsTable;
 import net.imagej.table.DoubleColumn;
 import net.imagej.table.FloatColumn;
@@ -327,15 +329,29 @@ public final class TableUtils {
 	public static Table<?, ?> createImageJTable(
 		final omero.grid.Column[] omeroColumns)
 	{
-		// TODO Decide if we really need this case logic.
-		for (int c = 0; c < omeroColumns.length; c++) {
-			if (!(omeroColumns[c] instanceof omero.grid.DoubleColumn)) {
-				// not all doubles
+		omero.grid.Column prev = omeroColumns[0];
+		for (int c = 1; c < omeroColumns.length; c++) {
+			// if table contains a mixture of column types, return a GenericTable
+			if (!prev.getClass().equals(omeroColumns[c].getClass())) {
 				return new DefaultGenericTable();
 			}
+			prev = omeroColumns[c];
 		}
-		// all double columns, yay
-		return new DefaultResultsTable();
+
+		// Uniform column types
+		prev = omeroColumns[0];
+		if (prev instanceof omero.grid.DoubleColumn) {
+			return new DefaultResultsTable();
+		}
+		else if (prev instanceof omero.grid.LongColumn) {
+			return new DefaultLongTable();
+		}
+		else if (prev instanceof omero.grid.BoolColumn) {
+			return new DefaultBoolTable();
+		}
+		else {
+			return new DefaultGenericTable();
+		}
 	}
 
 	public static Column<?> createImageJColumn(final omero.grid.Column column) {

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -53,6 +53,7 @@ import org.scijava.util.DoubleArray;
 import org.scijava.util.FloatArray;
 import org.scijava.util.IntArray;
 import org.scijava.util.LongArray;
+import org.scijava.util.PrimitiveArray;
 import org.scijava.util.ShortArray;
 
 /**
@@ -66,6 +67,7 @@ public final class TableUtils {
 		// NB: Prevent instantiation of utility class.
 	}
 
+	@SuppressWarnings("unchecked")
 	public static omero.grid.Column createOMEROColumn(
 		final Column<?> imageJColumn, final int index)
 	{
@@ -103,8 +105,16 @@ public final class TableUtils {
 		else if (type == File.class) {
 			omeroColumn = new omero.grid.FileColumn();
 		}
-		else if (type == String.class || type == Character.class) {
+		else if (type == Character.class) {
 			omeroColumn = new omero.grid.StringColumn();
+			// NB: Must set the maximum length of Strings contained in this column
+			((omero.grid.StringColumn) omeroColumn).size = 1l;
+		}
+		else if (type == String.class) {
+			omeroColumn = new omero.grid.StringColumn();
+			// NB: Must set the maximum length of Strings contained in this column
+			((omero.grid.StringColumn) omeroColumn).size =
+				longestString(((DefaultColumn<String>) imageJColumn).getArray());
 		}
 		else {
 			throw new UnsupportedOperationException("Not yet implemented: " +
@@ -580,4 +590,15 @@ public final class TableUtils {
 			((omero.grid.WellColumn) omeroColumn).values = ar.clone();
 		}
 	}
+
+	private static long longestString(final String[] array) {
+		long longest = 0;
+		for(int i = 0; i < array.length; i++) {
+			if(array[i] != null && array[i].length() > longest) {
+				longest = array[i].length();
+			}
+		}
+		return longest;
+	}
+
 }

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -286,8 +286,7 @@ public final class TableUtils {
 			final DefaultColumn<DoubleArray> imageJDoubleArrayColumn =
 				(DefaultColumn<DoubleArray>) imageJColumn;
 			for (int i = 0; i < data.length; i++) {
-				System.arraycopy(data[i], 0, imageJDoubleArrayColumn.get(i).getArray(),
-					offset, data.length);
+				populateArrayColumn(offset, data, imageJDoubleArrayColumn, i);
 			}
 		}
 		else if (omeroColumn instanceof omero.grid.FloatArrayColumn) {
@@ -295,8 +294,7 @@ public final class TableUtils {
 			final DefaultColumn<FloatArray> imageJFloatArrayColumn =
 				(DefaultColumn<FloatArray>) imageJColumn;
 			for (int i = 0; i < data.length; i++) {
-				System.arraycopy(data[i], 0, imageJFloatArrayColumn.get(i).getArray(),
-					offset, data.length);
+				populateArrayColumn(offset, data, imageJFloatArrayColumn, i);
 			}
 		}
 		else if (omeroColumn instanceof omero.grid.LongArrayColumn) {
@@ -304,8 +302,7 @@ public final class TableUtils {
 			final DefaultColumn<LongArray> imageJLongArrayColumn =
 				(DefaultColumn<LongArray>) imageJColumn;
 			for (int i = 0; i < data.length; i++) {
-				System.arraycopy(data[i], 0, imageJLongArrayColumn.get(i).getArray(),
-					offset, data.length);
+				populateArrayColumn(offset, data, imageJLongArrayColumn, i);
 			}
 		}
 		else if (omeroColumn instanceof omero.grid.StringColumn) {
@@ -445,5 +442,59 @@ public final class TableUtils {
 			d[q] = i[q];
 		}
 		return d;
+	}
+
+	private static void populateArrayColumn(final int offset,
+		final long[][] data, final DefaultColumn<LongArray> imageJLongArrayColumn,
+		final int col)
+	{
+		if (imageJLongArrayColumn.get(col) == null) {
+			imageJLongArrayColumn.set(col, new LongArray(data[col].clone()));
+		}
+		else if (imageJLongArrayColumn.get(col) != null &&
+			imageJLongArrayColumn.get(col).getArray() == null)
+		{
+			imageJLongArrayColumn.get(col).setArray(data[col].clone());
+		}
+		else {
+			System.arraycopy(data[col], 0, imageJLongArrayColumn.get(col).getArray(),
+				offset, data.length);
+		}
+	}
+
+	private static void populateArrayColumn(final int offset,
+		final float[][] data,
+		final DefaultColumn<FloatArray> imageJFloatArrayColumn, final int col)
+	{
+		if (imageJFloatArrayColumn.get(col) == null) {
+			imageJFloatArrayColumn.set(col, new FloatArray(data[col].clone()));
+		}
+		else if (imageJFloatArrayColumn.get(col) != null &&
+			imageJFloatArrayColumn.get(col).getArray() == null)
+		{
+			imageJFloatArrayColumn.get(col).setArray(data[col].clone());
+		}
+		else {
+			System.arraycopy(data[col], 0,
+				imageJFloatArrayColumn.get(col).getArray(), offset, data.length);
+		}
+	}
+
+	private static void populateArrayColumn(final int offset,
+		final double[][] data,
+		final DefaultColumn<DoubleArray> imageJDoubleArrayColumn, final int col)
+	{
+		if (imageJDoubleArrayColumn.get(col) == null) {
+			imageJDoubleArrayColumn.set(col, new DoubleArray(data[col].clone()));
+		}
+		else if (imageJDoubleArrayColumn.get(col) != null &&
+			imageJDoubleArrayColumn.get(col).getArray() == null)
+		{
+			imageJDoubleArrayColumn.get(col).setArray(data[col].clone());
+		}
+		else {
+			System.arraycopy(data[col], 0, imageJDoubleArrayColumn.get(col)
+				.getArray(), offset, data.length);
+		}
 	}
 }

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import net.imagej.table.Column;
+import net.imagej.table.DoubleColumn;
+
+/**
+ * Utility class for working with converting between ImageJ and OMERO tables.
+ * 
+ * @author Curtis Rueden
+ */
+public final class TableUtils {
+
+	private TableUtils() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	public static omero.grid.Column createOMEROColumn(
+		final Column<?> imageJColumn, final int index)
+	{
+		// FIXME: need ImageJ to remember type of column via a getType() method
+		// For now, we hardcode.
+		final omero.grid.Column omeroColumn;
+		if (imageJColumn instanceof DoubleColumn) {
+			omeroColumn = new omero.grid.DoubleColumn();
+		}
+		else {
+			final Class<?> type = imageJColumn.get(0).getClass();
+			throw new UnsupportedOperationException("Not yet implemented: " +
+				type.getName());
+			/* TODO:
+			BoolColumn
+			DoubleArrayColumn
+			DoubleColumn
+			FileColumn
+			FloatArrayColumn
+			ImageColumn
+			LongArrayColumn
+			LongColumn
+			MaskColumn
+			PlateColumn
+			RoiColumn
+			StringColumn
+			WellColumn
+			*/
+		}
+		omeroColumn.name = imageJColumn.getHeader();
+		if (omeroColumn.name == null) omeroColumn.name = "" + index;
+		return omeroColumn;
+	}
+
+	public static void populateOMEROColumn(final Column<?> imageJColumn,
+		final omero.grid.Column omeroColumn)
+	{
+		if (imageJColumn instanceof DoubleColumn) {
+			final DoubleColumn doubleColumn = (DoubleColumn) imageJColumn;
+			final omero.grid.DoubleColumn omeroDColumn =
+				(omero.grid.DoubleColumn) omeroColumn;
+			omeroDColumn.values = doubleColumn.getArray();
+		}
+		throw new UnsupportedOperationException("Unsupported column type: " +
+			imageJColumn.getClass().getName());
+	}
+
+}

--- a/src/main/java/net/imagej/omero/TableUtils.java
+++ b/src/main/java/net/imagej/omero/TableUtils.java
@@ -200,6 +200,7 @@ public final class TableUtils {
 				(omero.grid.DoubleArrayColumn) omeroColumn;
 			final double[][] values = new double[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = new double[defaultColumn.get(i).size()];
 				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
 					defaultColumn.get(i).size());
@@ -213,6 +214,7 @@ public final class TableUtils {
 				(omero.grid.FloatArrayColumn) omeroColumn;
 			final float[][] values = new float[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = new float[defaultColumn.get(i).size()];
 				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
 					defaultColumn.get(i).size());
@@ -226,6 +228,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = new long[defaultColumn.get(i).size()];
 				System.arraycopy(defaultColumn.get(i).getArray(), 0, values[i], 0,
 					defaultColumn.get(i).size());
@@ -239,6 +242,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
@@ -250,6 +254,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
@@ -261,6 +266,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;
@@ -272,6 +278,7 @@ public final class TableUtils {
 				(omero.grid.LongArrayColumn) omeroColumn;
 			final long[][] values = new long[defaultColumn.size()][];
 			for (int i = 0; i < values.length; i++) {
+				if (defaultColumn.get(i) == null) continue;
 				values[i] = toLongArray(defaultColumn.get(i).getArray(), s);
 			}
 			omeroLAColumn.values = values;

--- a/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero.commands;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import net.imagej.omero.DefaultOMEROService;
+import net.imagej.omero.OMEROCommand;
+import net.imagej.omero.OMEROCredentials;
+import net.imagej.omero.OMEROService;
+import net.imagej.table.Table;
+import omero.ServerError;
+
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.menu.MenuConstants;
+import org.scijava.plugin.Menu;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/** An ImageJ command for downloading a results table from an OMERO server. */
+@Plugin(type = Command.class, label = "Import Table from OMERO", menu = {
+	@Menu(label = MenuConstants.FILE_LABEL, weight = MenuConstants.FILE_WEIGHT,
+		mnemonic = MenuConstants.FILE_MNEMONIC),
+	@Menu(label = "Import", weight = 6),
+	@Menu(label = "OMERO Table...", weight = 100, mnemonic = 'o') })
+public class OpenTableFromOMERO extends OMEROCommand {
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private OMEROService omeroService;
+
+	@Parameter
+	private long tableID;
+
+	@Parameter(type = ItemIO.OUTPUT)
+	private Table<?, ?> table;
+
+	@Override
+	public void run() {
+		final OMEROCredentials credentials = new OMEROCredentials();
+		credentials.setServer(getServer());
+		credentials.setPort(getPort());
+		credentials.setUser(getUser());
+		credentials.setPassword(getPassword());
+		try {
+			table = ((DefaultOMEROService) omeroService).downloadTable(credentials, tableID);
+			log.info("GOT A TABLE: " + table);//TEMP
+			System.out.println("GOT A TABLE: " + table);
+		}
+		catch (ServerError exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (PermissionDeniedException exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (CannotCreateSessionException exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
@@ -71,8 +71,6 @@ public class OpenTableFromOMERO extends OMEROCommand {
 		credentials.setPassword(getPassword());
 		try {
 			table = ((DefaultOMEROService) omeroService).downloadTable(credentials, tableID);
-			log.info("GOT A TABLE: " + table);//TEMP
-			System.out.println("GOT A TABLE: " + table);
 		}
 		catch (ServerError exc) {
 			log.error(exc);

--- a/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
@@ -27,12 +27,16 @@ package net.imagej.omero.commands;
 
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+
+import java.util.concurrent.ExecutionException;
+
 import net.imagej.omero.DefaultOMEROService;
 import net.imagej.omero.OMEROCommand;
 import net.imagej.omero.OMEROCredentials;
 import net.imagej.omero.OMEROService;
 import net.imagej.table.Table;
 import omero.ServerError;
+import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
 
 import org.scijava.ItemIO;
@@ -89,6 +93,16 @@ public class OpenTableFromOMERO extends OMEROCommand {
 			cancel("Error talking to OMERO: " + exc.getMessage());
 		}
 		catch (DSOutOfServiceException exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (ExecutionException exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (DSAccessException exc) {
 			log.error(exc);
 			exc.printStackTrace();
 			cancel("Error talking to OMERO: " + exc.getMessage());

--- a/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/OpenTableFromOMERO.java
@@ -33,6 +33,7 @@ import net.imagej.omero.OMEROCredentials;
 import net.imagej.omero.OMEROService;
 import net.imagej.table.Table;
 import omero.ServerError;
+import omero.gateway.exception.DSOutOfServiceException;
 
 import org.scijava.ItemIO;
 import org.scijava.command.Command;
@@ -83,6 +84,11 @@ public class OpenTableFromOMERO extends OMEROCommand {
 			cancel("Error talking to OMERO: " + exc.getMessage());
 		}
 		catch (CannotCreateSessionException exc) {
+			log.error(exc);
+			exc.printStackTrace();
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (DSOutOfServiceException exc) {
 			log.error(exc);
 			exc.printStackTrace();
 			cancel("Error talking to OMERO: " + exc.getMessage());

--- a/src/main/java/net/imagej/omero/commands/SaveImageToOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/SaveImageToOMERO.java
@@ -56,6 +56,9 @@ public class SaveImageToOMERO extends OMEROCommand {
 	@Parameter
 	private Dataset dataset;
 
+	@Parameter
+	private long datasetID;
+
 	@Override
 	public void run() {
 		final String omeroDestination =
@@ -64,6 +67,7 @@ public class SaveImageToOMERO extends OMEROCommand {
 			"&port=" + getPort() + //
 			"&user=" + getUser() + //
 			"&password=" + getPassword() + //
+			"&datasetID=" + datasetID + //
 			".omero";
 
 		try {

--- a/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
@@ -25,17 +25,17 @@
 
 package net.imagej.omero.commands;
 
-import java.util.concurrent.ExecutionException;
-
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+
+import java.util.concurrent.ExecutionException;
+
 import net.imagej.omero.DefaultOMEROService;
 import net.imagej.omero.OMEROCommand;
 import net.imagej.omero.OMEROCredentials;
 import net.imagej.omero.OMEROService;
-import net.imagej.table.DefaultResultsTable;
-import net.imagej.table.ResultsTable;
 import net.imagej.table.Table;
+import net.imagej.table.TableDisplay;
 import omero.ServerError;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
@@ -64,8 +64,8 @@ public class SaveTableToOMERO extends OMEROCommand {
 	@Parameter
 	private String name;
 
-	@Parameter(required = false)
-	private Table<?, ?> table;
+	@Parameter
+	private TableDisplay tableDisplay;
 
 	@Parameter
 	private long imageID;
@@ -77,8 +77,7 @@ public class SaveTableToOMERO extends OMEROCommand {
 		credentials.setPort(getPort());
 		credentials.setUser(getUser());
 		credentials.setPassword(getPassword());
-
-		if (table == null) table = createBaseballTable();
+		final Table<?, ?> table = tableDisplay.get(0);
 
 		try {
 			((DefaultOMEROService) omeroService).uploadTable(credentials, name, table, imageID);
@@ -107,43 +106,6 @@ public class SaveTableToOMERO extends OMEROCommand {
 			log.error(exc);
 			cancel("Error attaching table to OMERO image: " + exc.getMessage());
 		}
-	}
-
-	private ResultsTable createBaseballTable() {
-		final double[][] data = {
-			{1978, 21, .273},
-			{1979, 22, .322},
-			{1980, 23, .304},
-			{1981, 24, .267},
-			{1982, 25, .302},
-			{1983, 26, .270},
-			{1984, 27, .217},
-			{1985, 28, .297},
-			{1986, 29, .281},
-			{1987, 30, .353},
-			{1988, 31, .312},
-			{1989, 32, .315},
-			{1990, 33, .285},
-			{1991, 34, .325},
-			{1992, 35, .320},
-			{1993, 36, .332},
-			{1994, 37, .341},
-			{1995, 38, .270},
-			{1996, 39, .341},
-			{1997, 40, .305},
-			{1998, 41, .281},
-		};
-		DefaultResultsTable baseball = new DefaultResultsTable(data[0].length, data.length);
-		baseball.setColumnHeader(0, "Year");
-		baseball.setColumnHeader(1, "Age");
-		baseball.setColumnHeader(2, "BA");
-		baseball.setRowHeader(9, "Best");
-		for (int row = 0; row < data.length; row++) {
-			for (int col = 0; col < data[row].length; col++) {
-				baseball.setValue(col, row, data[row][col]);
-			}
-		}
-		return baseball;
 	}
 
 }

--- a/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
@@ -85,7 +85,7 @@ public class SaveTableToOMERO extends OMEROCommand {
 		}
 		catch (ServerError exc) {
 			log.error(exc);
-			cancel("Error talking to OMERO: " + exc.getMessage());
+			cancel("Error talking to OMERO: " + exc.message);
 		}
 		catch (PermissionDeniedException exc) {
 			log.error(exc);

--- a/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero.commands;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import net.imagej.omero.DefaultOMEROService;
+import net.imagej.omero.OMEROCommand;
+import net.imagej.omero.OMEROCredentials;
+import net.imagej.omero.OMEROService;
+import net.imagej.table.DefaultResultsTable;
+import net.imagej.table.ResultsTable;
+import net.imagej.table.Table;
+import omero.ServerError;
+
+import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.menu.MenuConstants;
+import org.scijava.plugin.Menu;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/** An ImageJ command for uploading a results table to an OMERO server. */
+@Plugin(type = Command.class, label = "Export Table to OMERO", menu = {
+	@Menu(label = MenuConstants.FILE_LABEL, weight = MenuConstants.FILE_WEIGHT,
+		mnemonic = MenuConstants.FILE_MNEMONIC),
+	@Menu(label = "Export", weight = 6),
+	@Menu(label = "OMERO Table... ", weight = 100, mnemonic = 'o') })
+public class SaveTableToOMERO extends OMEROCommand {
+
+	@Parameter
+	private LogService log;
+
+	@Parameter
+	private OMEROService omeroService;
+
+	@Parameter
+	private String name;
+
+	@Parameter(required = false)
+	private Table<?, ?> table;
+
+	@Override
+	public void run() {
+		final OMEROCredentials credentials = new OMEROCredentials();
+		credentials.setServer(getServer());
+		credentials.setPort(getPort());
+		credentials.setUser(getUser());
+		credentials.setPassword(getPassword());
+
+		if (table == null) table = createBaseballTable();
+
+		try {
+			((DefaultOMEROService) omeroService).uploadTable(credentials, name, table);
+		}
+		catch (ServerError exc) {
+			log.error(exc);
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (PermissionDeniedException exc) {
+			log.error(exc);
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (CannotCreateSessionException exc) {
+			log.error(exc);
+			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+	}
+
+	private ResultsTable createBaseballTable() {
+		final double[][] data = {
+			{1978, 21, .273},
+			{1979, 22, .322},
+			{1980, 23, .304},
+			{1981, 24, .267},
+			{1982, 25, .302},
+			{1983, 26, .270},
+			{1984, 27, .217},
+			{1985, 28, .297},
+			{1986, 29, .281},
+			{1987, 30, .353},
+			{1988, 31, .312},
+			{1989, 32, .315},
+			{1990, 33, .285},
+			{1991, 34, .325},
+			{1992, 35, .320},
+			{1993, 36, .332},
+			{1994, 37, .341},
+			{1995, 38, .270},
+			{1996, 39, .341},
+			{1997, 40, .305},
+			{1998, 41, .281},
+		};
+		DefaultResultsTable baseball = new DefaultResultsTable(data[0].length, data.length);
+		baseball.setColumnHeader(0, "Year");
+		baseball.setColumnHeader(1, "Age");
+		baseball.setColumnHeader(2, "BA");
+		baseball.setRowHeader(9, "Best");
+		for (int row = 0; row < data.length; row++) {
+			for (int col = 0; col < data[row].length; col++) {
+				baseball.setValue(col, row, data[row][col]);
+			}
+		}
+		return baseball;
+	}
+
+}

--- a/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/SaveTableToOMERO.java
@@ -25,6 +25,8 @@
 
 package net.imagej.omero.commands;
 
+import java.util.concurrent.ExecutionException;
+
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
 import net.imagej.omero.DefaultOMEROService;
@@ -35,6 +37,8 @@ import net.imagej.table.DefaultResultsTable;
 import net.imagej.table.ResultsTable;
 import net.imagej.table.Table;
 import omero.ServerError;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
 
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
@@ -63,6 +67,9 @@ public class SaveTableToOMERO extends OMEROCommand {
 	@Parameter(required = false)
 	private Table<?, ?> table;
 
+	@Parameter
+	private long imageID;
+
 	@Override
 	public void run() {
 		final OMEROCredentials credentials = new OMEROCredentials();
@@ -74,7 +81,7 @@ public class SaveTableToOMERO extends OMEROCommand {
 		if (table == null) table = createBaseballTable();
 
 		try {
-			((DefaultOMEROService) omeroService).uploadTable(credentials, name, table);
+			((DefaultOMEROService) omeroService).uploadTable(credentials, name, table, imageID);
 		}
 		catch (ServerError exc) {
 			log.error(exc);
@@ -87,6 +94,18 @@ public class SaveTableToOMERO extends OMEROCommand {
 		catch (CannotCreateSessionException exc) {
 			log.error(exc);
 			cancel("Error talking to OMERO: " + exc.getMessage());
+		}
+		catch (ExecutionException exc) {
+			log.error(exc);
+			cancel("Error attaching table to OMERO image: " + exc.getMessage());
+		}
+		catch (DSOutOfServiceException exc) {
+			log.error(exc);
+			cancel("Error attaching table to OMERO image: " + exc.getMessage());
+		}
+		catch (DSAccessException exc) {
+			log.error(exc);
+			cancel("Error attaching table to OMERO image: " + exc.getMessage());
 		}
 	}
 

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.ExecutionException;
+
 import net.imagej.table.BoolColumn;
 import net.imagej.table.BoolTable;
 import net.imagej.table.DefaultColumn;
@@ -38,6 +40,7 @@ import net.imagej.table.LongTable;
 import net.imagej.table.ResultsTable;
 import net.imagej.table.Table;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,16 +50,18 @@ import org.scijava.util.LongArray;
 
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+import mockit.Expectations;
 import mockit.Mocked;
-import mockit.VerificationsInOrder;
 import omero.ServerError;
 import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
-import omero.grid.SharedResourcesPrx;
-import omero.grid.TablePrx;
-import omero.model.OriginalFile;
-import omero.model.OriginalFileI;
+import omero.gateway.facility.TablesFacility;
+import omero.gateway.model.ImageData;
+import omero.gateway.model.TableData;
+import omero.gateway.model.TableDataColumn;
+import omero.model.ImageI;
 
 /**
  * Tests {@link DefaultOMEROService#downloadTable(OMEROCredentials, long)}.
@@ -65,496 +70,356 @@ import omero.model.OriginalFileI;
  */
 public class DownloadTableTest {
 
-	private OMEROService service;
 	private OMEROCredentials credentials;
+	private OMEROService service;
+
+	@Mocked
+	private DefaultOMEROSession session;
+
+	@Mocked
+	private Gateway gateway;
+
+	@Mocked
+	private TablesFacility tablesFacility;
 
 	@Before
-	public void setUp() throws Exception {
-		service = new Context(OMEROService.class).service(OMEROService.class);
+	public void setUp() {
+		credentials = new OMEROCredentials();
+		service = new Context(OMEROService.class).getService(OMEROService.class);
 	}
 
 	@After
 	public void tearDown() {
-		if (service != null) {
-			service.getContext().dispose();
-			service = null;
+		service.dispose();
+	}
+
+	@Test
+	public void downloadBoolTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, Boolean.class), new TableDataColumn("Header 2", 1,
+				Boolean.class), new TableDataColumn("Header 3", 2, Boolean.class) };
+		final Object[][] data = new Object[3][];
+		data[0] = new Boolean[] { true, true, true, true, false, false, false,
+			false };
+		data[1] = new Boolean[] { true, true, false, false, true, true, false,
+			false };
+		data[2] = new Boolean[] { true, false, true, false, true, false, true,
+			false };
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(8);
+
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(BoolTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 8);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals(data[c][r], imageJTable.get(c, r));
+			}
 		}
 	}
 
-//	@Test
-//	public void downloadBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[3];
-//		final omero.grid.BoolColumn bOne = new omero.grid.BoolColumn();
-//		bOne.name = "Header 1";
-//		bOne.values = new boolean[] { true, true, true, true, false, false, false,
-//			false };
-//		final omero.grid.BoolColumn bTwo = new omero.grid.BoolColumn();
-//		bTwo.name = "Header 2";
-//		bTwo.values = new boolean[] { true, true, false, false, true, true, false,
-//			false };
-//		final omero.grid.BoolColumn bThree = new omero.grid.BoolColumn();
-//		bThree.name = "Header 3";
-//		bThree.values = new boolean[] { true, false, true, false, true, false, true,
-//			false };
-//		cols[0] = bOne;
-//		cols[1] = bTwo;
-//		cols[2] = bThree;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1, 2 }, 8);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(BoolTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 3);
-//		assertEquals(imageJTable.getRowCount(), 8);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertEquals(((BoolTable) imageJTable).getValue(c, r),
-//					((omero.grid.BoolColumn) cols[c]).values[r]);
-//			}
-//		}
-//	}
-//
-//	@Test
-//	public void downloadLongTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[4];
-//		final omero.grid.LongColumn lOne = new omero.grid.LongColumn();
-//		lOne.name = "Header 1";
-//		lOne.values = new long[] { 0l, -9223372036854775808l,
-//			9223372036854775807l };
-//		final omero.grid.LongColumn lTwo = new omero.grid.LongColumn();
-//		lTwo.name = "Header 2";
-//		lTwo.values = new long[] { 134l, 5415145l, 4775807l };
-//		final omero.grid.LongColumn lThree = new omero.grid.LongColumn();
-//		lThree.name = "Header 3";
-//		lThree.values = new long[] { -1898l, -97234l, 75807l };
-//		final omero.grid.LongColumn lFour = new omero.grid.LongColumn();
-//		lFour.name = "Header 4";
-//		lFour.values = new long[] { 19048l, -123l, 4l };
-//		cols[0] = lOne;
-//		cols[1] = lTwo;
-//		cols[2] = lThree;
-//		cols[3] = lFour;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1, 2, 3 }, 3);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(LongTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 4);
-//		assertEquals(imageJTable.getRowCount(), 3);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-//		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertEquals(((LongTable) imageJTable).getValue(c, r),
-//					((omero.grid.LongColumn) cols[c]).values[r]);
-//			}
-//		}
-//	}
-//
-//	@Test
-//	public void downloadDoubleTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[2];
-//		final omero.grid.DoubleColumn dOne = new omero.grid.DoubleColumn();
-//		dOne.name = "Header 1";
-//		dOne.values = new double[] { 0.125, -0.5, 923014712408917.25, -241.03125,
-//			0.0 };
-//		final omero.grid.DoubleColumn dTwo = new omero.grid.DoubleColumn();
-//		dTwo.name = "Header 2";
-//		dTwo.values = new double[] { 1002.125, 908082.5, 59871249.0625, -7.25,
-//			4.5 };
-//		cols[0] = dOne;
-//		cols[1] = dTwo;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1 }, 5);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(ResultsTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 2);
-//		assertEquals(imageJTable.getRowCount(), 5);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertEquals(((ResultsTable) imageJTable).getValue(c, r),
-//					((omero.grid.DoubleColumn) cols[c]).values[r], 0);
-//			}
-//		}
-//	}
-//
-//	@SuppressWarnings("unchecked")
-//	@Test
-//	public void downloadLongArrayTable(
-//		@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[2];
-//		final omero.grid.LongArrayColumn laOne = new omero.grid.LongArrayColumn();
-//		laOne.name = "Header 1";
-//		laOne.values = new long[][] { { 0l, -9223372036854775808l }, { 134l,
-//			9223372036854775807l } };
-//		final omero.grid.LongArrayColumn laTwo = new omero.grid.LongArrayColumn();
-//		laTwo.name = "Header 2";
-//		laTwo.values = new long[][] { { -2139847, 1023894 }, { 12, 23415 } };
-//		cols[0] = laOne;
-//		cols[1] = laTwo;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1 }, 2);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(GenericTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 2);
-//		assertEquals(imageJTable.getRowCount(), 2);
-//		assertEquals(imageJTable.get(0).size(), 2);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
-//				assertTrue(imageJTable.get(c).getType() == LongArray.class);
-//				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c)).get(r)
-//					.getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
-//			}
-//		}
-//	}
-//
-//	@SuppressWarnings("unchecked")
-//	@Test
-//	public void downloadStringTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[3];
-//		final omero.grid.StringColumn sOne = new omero.grid.StringColumn();
-//		sOne.name = "Header 1";
-//		sOne.values = new String[] { "abc", "123", "hi!" };
-//		final omero.grid.StringColumn sTwo = new omero.grid.StringColumn();
-//		sTwo.name = "Header 2";
-//		sTwo.values = new String[] { "Good Morning", "Good evening", "good night" };
-//		final omero.grid.StringColumn sThree = new omero.grid.StringColumn();
-//		sThree.name = "Header 3";
-//		sThree.values = new String[] { "good afternoon", "hey", "hello." };
-//		cols[0] = sOne;
-//		cols[1] = sTwo;
-//		cols[2] = sThree;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1, 2 }, 3);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(GenericTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 3);
-//		assertEquals(imageJTable.getRowCount(), 3);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
-//				assertTrue(imageJTable.get(c).getType() == String.class);
-//				assertEquals(((DefaultColumn<String>) imageJTable.get(c)).get(r),
-//					((omero.grid.StringColumn) cols[c]).values[r]);
-//			}
-//		}
-//	}
-//
-//	@SuppressWarnings("unchecked")
-//	@Test
-//	public void downloadMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[4];
-//		final omero.grid.StringColumn mOne = new omero.grid.StringColumn();
-//		mOne.name = "Header 1";
-//		mOne.values = new String[] { "abc", "123", "hi!" };
-//		final omero.grid.BoolColumn mTwo = new omero.grid.BoolColumn();
-//		mTwo.name = "Header 2";
-//		mTwo.values = new boolean[] { false, true, false };
-//		final omero.grid.DoubleArrayColumn mThree =
-//			new omero.grid.DoubleArrayColumn();
-//		mThree.name = "Header 3";
-//		mThree.values = new double[][] { { 0.125, 3879123.5, -93.25 }, { 0,
-//			-123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
-//		final omero.grid.LongColumn mFour = new omero.grid.LongColumn();
-//		mFour.name = "Header 4";
-//		mFour.values = new long[] { -9028131908l, 0, 12 };
-//		cols[0] = mOne;
-//		cols[1] = mTwo;
-//		cols[2] = mThree;
-//		cols[3] = mFour;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1, 2, 3 }, 3);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(GenericTable.class.isInstance(imageJTable));
-//		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(0)));
-//		assertTrue(imageJTable.get(0).getType() == String.class);
-//		assertTrue(BoolColumn.class.isInstance(imageJTable.get(1)));
-//		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(2)));
-//		assertTrue(imageJTable.get(2).getType() == DoubleArray.class);
-//		assertTrue(LongColumn.class.isInstance(imageJTable.get(3)));
-//
-//		assertEquals(imageJTable.getColumnCount(), 4);
-//		assertEquals(imageJTable.getRowCount(), 3);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-//		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			assertEquals(((DefaultColumn<String>) imageJTable.get(0)).get(r),
-//				((omero.grid.StringColumn) cols[0]).values[r]);
-//		}
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			assertEquals(((BoolColumn) imageJTable.get(1)).getValue(r),
-//				((omero.grid.BoolColumn) cols[1]).values[r]);
-//		}
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2)).get(r)
-//				.getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r], 0);
-//		}
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			assertEquals(((LongColumn) imageJTable.get(3)).getValue(r),
-//				((omero.grid.LongColumn) cols[3]).values[r]);
-//		}
-//	}
-//
-//	@Test
-//	public void downloadRefTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-//		DSOutOfServiceException
-//	{
-//		// Setup OMERO data structures
-//		final omero.grid.Column[] cols = new omero.grid.Column[3];
-//		final omero.grid.ImageColumn rOne = new omero.grid.ImageColumn();
-//		rOne.name = "Header 1";
-//		rOne.values = new long[] { 101, 102, 103 };
-//		final omero.grid.ImageColumn rTwo = new omero.grid.ImageColumn();
-//		rTwo.name = "Header 2";
-//		rTwo.values = new long[] { 201, 202, 203 };
-//		final omero.grid.ImageColumn rThree = new omero.grid.ImageColumn();
-//		rThree.name = "Header 3";
-//		rThree.values = new long[] { 301, 302, 303 };
-//		cols[0] = rOne;
-//		cols[1] = rTwo;
-//		cols[2] = rThree;
-//
-//		final omero.grid.Data testData = new omero.grid.Data();
-//		testData.columns = cols;
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-//			testData, new long[] { 0, 1, 2 }, 3);
-//
-//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-//			.downloadTable(credentials, 0);
-//
-//		// Verify method calls occurred in expected order
-//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-//
-//		// Tests
-//		assertTrue(GenericTable.class.isInstance(imageJTable));
-//		assertEquals(imageJTable.getColumnCount(), 3);
-//		assertEquals(imageJTable.getRowCount(), 3);
-//
-//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-//
-//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-//				assertTrue(OMERORefColumn.class.isInstance(imageJTable.get(c)));
-//				assertTrue(imageJTable.get(c).getType() == Long.class);
-//				assertEquals(((OMERORefColumn) imageJTable.get(c)).getOMERORef(),
-//					OMERORef.IMAGE);
-//				assertEquals(((OMERORefColumn) imageJTable.get(c)).get(r).longValue(),
-//					((omero.grid.ImageColumn) cols[c]).values[r]);
-//			}
-//		}
-//	}
-//
-//	// -- Helper methods --
-//
-//	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-//		final Gateway gatewayMock, final SecurityContext scMock,
-//		final SharedResourcesPrx srMock, final TablePrx tableMock,
-//		final omero.grid.Column[] cols, final omero.grid.Data testData,
-//		final long[] ind, final int rows) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException,
-//		DSOutOfServiceException
-//	{
-//		new NonStrictExpectations() {
-//
-//			{
-//				// Expect constructors
-//				new DefaultOMEROSession(withNotNull());
-//				new OriginalFileI(anyLong, false);
-//
-//				sessionMock.getGateway();
-//				result = gatewayMock;
-//				sessionMock.getSecurityContext();
-//				result = scMock;
-//				gatewayMock.getSharedResources(scMock);
-//				result = srMock;
-//				srMock.openTable((OriginalFile) any);
-//				result = tableMock;
-//
-//				tableMock.getNumberOfRows();
-//				result = rows;
-//
-//				tableMock.getHeaders();
-//				result = cols;
-//
-//				tableMock.getHeaders();
-//				result = cols;
-//
-//				tableMock.read(ind, 0, rows);
-//				result = testData;
-//
-//				tableMock.close();
-//			}
-//		};
-//	}
-//
-//	private void verify(final DefaultOMEROSession sessionMock,
-//		final Gateway gatewayMock, final SecurityContext scMock,
-//		final SharedResourcesPrx srMock, final TablePrx tableMock)
-//		throws ServerError, DSOutOfServiceException
-//	{
-//		new VerificationsInOrder() {
-//
-//			{
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.openTable((OriginalFile) any);
-//				tableMock.getNumberOfRows();
-//				tableMock.getHeaders();
-//				tableMock.getHeaders();
-//				tableMock.read((long[]) any, anyLong, anyLong);
-//				tableMock.close();
-//			}
-//		};
-//	}
+	@Test
+	public void downloadLongTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, Long.class), new TableDataColumn("Header 2", 1,
+				Long.class), new TableDataColumn("Header 3", 2, Long.class),
+			new TableDataColumn("Header 4", 3, Long.class) };
+		final Object[][] data = new Object[4][];
+		data[0] = new Long[] { 0l, -9223372036854775808l, 9223372036854775807l };
+		data[1] = new Long[] { 134l, 5415145l, 4775807l };
+		data[2] = new Long[] { -1898l, -97234l, 75807l };
+		data[3] = new Long[] { 19048l, -123l, 4l };
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(3);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(LongTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 4);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals(data[c][r], imageJTable.get(c, r));
+			}
+		}
+	}
+
+	@Test
+	public void downloadDoubleTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, Double.class), new TableDataColumn("Header 2", 1,
+				Double.class) };
+		final Object[][] data = new Object[2][];
+		data[0] = new Double[] { 0.125, -0.5, 923014712408917.25, -241.03125, 0.0 };
+		data[1] = new Double[] { 1002.125, 908082.5, 59871249.0625, -7.25, 4.5 };
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(5);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(ResultsTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 2);
+		assertEquals(imageJTable.getRowCount(), 5);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals((double) data[c][r], ((ResultsTable) imageJTable).get(c,
+					r), 0);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void downloadLongArrayTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, Long[].class), new TableDataColumn("Header 2", 1,
+				Long[].class) };
+		final Object[][] data = new Object[2][];
+		data[0] = new Long[][] { { 0l, -9223372036854775808l }, { 134l,
+			9223372036854775807l } };
+		data[1] = new Long[][] { { -2139847l, 1023894l }, { 12l, 23415l } };
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(2);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 2);
+		assertEquals(imageJTable.getRowCount(), 2);
+		assertEquals(imageJTable.get(0).size(), 2);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == LongArray.class);
+				final Long[] l = (Long[]) data[c][r];
+				final Object[] ijl = ((DefaultColumn<LongArray>) imageJTable.get(c)).get(
+					r).toArray();
+				assertArrayEquals(l, ijl);
+			}
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void downloadStringTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		/// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, String.class), new TableDataColumn("Header 2", 1,
+				String.class), new TableDataColumn("Header 3", 2, String.class) };
+		final Object[][] data = new Object[3][];
+		data[0] = new String[] { "abc", "123", "hi!" };
+		data[1] = new String[] { "Good Morning", "Good evening", "good night" };
+		data[2] = new String[] { "good afternoon", "hey", "hello." };
+
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(3);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == String.class);
+				assertEquals(data[c][r], ((DefaultColumn<String>) imageJTable.get(c))
+					.get(r));
+			}
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void downloadMixedTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		/// Setup OMERO data structures
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, String.class), new TableDataColumn("Header 2", 1,
+				Boolean.class), new TableDataColumn("Header 3", 2, Double[].class),
+			new TableDataColumn("Header 4", 3, Long.class) };
+		final Object[][] data = new Object[4][];
+		data[0] = new String[] { "abc", "123", "hi!" };
+		data[1] = new Boolean[] { false, true, false };
+		data[2] = new Double[][] { { 0.125, 3879123.5, -93.25 }, { 0d, -123353.03125,
+			-5.5 }, { 100.25, 0.125, -9000.5 } };
+		data[3] = new Long[] { -9028131908l, 0l, 12l };
+
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(3);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(0)));
+		assertTrue(imageJTable.get(0).getType() == String.class);
+		assertTrue(BoolColumn.class.isInstance(imageJTable.get(1)));
+		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(2)));
+		assertTrue(imageJTable.get(2).getType() == DoubleArray.class);
+		assertTrue(LongColumn.class.isInstance(imageJTable.get(3)));
+
+		assertEquals(imageJTable.getColumnCount(), 4);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++)
+			assertEquals(data[0][r], ((DefaultColumn<String>) imageJTable.get(0)).get(
+				r));
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++)
+			assertEquals(data[1][r], ((BoolColumn) imageJTable.get(1)).getValue(r));
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++)
+			assertArrayEquals((Double[]) data[2][r],
+				((DefaultColumn<DoubleArray>) imageJTable.get(2)).get(r).toArray());
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++)
+			assertEquals(data[3][r], ((LongColumn) imageJTable.get(3)).getValue(r));
+	}
+
+	@Test
+	public void downloadRefTable() throws PermissionDeniedException,
+		CannotCreateSessionException, ServerError, DSOutOfServiceException,
+		ExecutionException, DSAccessException
+	{
+		final TableDataColumn[] tdc = new TableDataColumn[] { new TableDataColumn(
+			"Header 1", 0, ImageData.class), new TableDataColumn("Header 2", 1,
+				ImageData.class), new TableDataColumn("Header 3", 2, ImageData.class) };
+		final Object[][] data = new Object[3][3];
+		final long[][] ids = new long[][] { { 101, 102, 103 }, { 201, 202, 203 }, {
+			301, 302, 303 } };
+		for (int i = 0; i < 3; i++) {
+			for (int j = 0; j < 3; j++) {
+				data[i][j] = new ImageData(new ImageI(ids[i][j], false));
+			}
+		}
+		final TableData table = new TableData(tdc, data);
+		table.setNumberOfRows(3);
+
+		// Create expectations
+		setUpMethodCalls(table);
+
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(OMERORefColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == Long.class);
+				assertEquals(((OMERORefColumn) imageJTable.get(c)).getOMERORef(),
+					OMERORef.IMAGE);
+				assertEquals(ids[c][r], ((OMERORefColumn) imageJTable.get(c)).get(r)
+					.longValue());
+			}
+		}
+	}
+
+	// -- Helper methods --
+
+	private void setUpMethodCalls(final TableData table) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
+	{
+		new Expectations() {
+
+			{
+				new DefaultOMEROSession(credentials);
+
+				gateway.getFacility(TablesFacility.class);
+				result = tablesFacility;
+				tablesFacility.getTable((SecurityContext) any, anyLong, anyLong,
+					anyLong);
+				result = table;
+			}
+		};
+	}
 }

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -82,480 +82,480 @@ public class DownloadTableTest {
 		}
 	}
 
-	@Test
-	public void downloadBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[3];
-		final omero.grid.BoolColumn bOne = new omero.grid.BoolColumn();
-		bOne.name = "Header 1";
-		bOne.values = new boolean[] { true, true, true, true, false, false, false,
-			false };
-		final omero.grid.BoolColumn bTwo = new omero.grid.BoolColumn();
-		bTwo.name = "Header 2";
-		bTwo.values = new boolean[] { true, true, false, false, true, true, false,
-			false };
-		final omero.grid.BoolColumn bThree = new omero.grid.BoolColumn();
-		bThree.name = "Header 3";
-		bThree.values = new boolean[] { true, false, true, false, true, false, true,
-			false };
-		cols[0] = bOne;
-		cols[1] = bTwo;
-		cols[2] = bThree;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1, 2 }, 8);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(BoolTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 3);
-		assertEquals(imageJTable.getRowCount(), 8);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertEquals(((BoolTable) imageJTable).getValue(c, r),
-					((omero.grid.BoolColumn) cols[c]).values[r]);
-			}
-		}
-	}
-
-	@Test
-	public void downloadLongTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[4];
-		final omero.grid.LongColumn lOne = new omero.grid.LongColumn();
-		lOne.name = "Header 1";
-		lOne.values = new long[] { 0l, -9223372036854775808l,
-			9223372036854775807l };
-		final omero.grid.LongColumn lTwo = new omero.grid.LongColumn();
-		lTwo.name = "Header 2";
-		lTwo.values = new long[] { 134l, 5415145l, 4775807l };
-		final omero.grid.LongColumn lThree = new omero.grid.LongColumn();
-		lThree.name = "Header 3";
-		lThree.values = new long[] { -1898l, -97234l, 75807l };
-		final omero.grid.LongColumn lFour = new omero.grid.LongColumn();
-		lFour.name = "Header 4";
-		lFour.values = new long[] { 19048l, -123l, 4l };
-		cols[0] = lOne;
-		cols[1] = lTwo;
-		cols[2] = lThree;
-		cols[3] = lFour;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1, 2, 3 }, 3);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(LongTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 4);
-		assertEquals(imageJTable.getRowCount(), 3);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertEquals(((LongTable) imageJTable).getValue(c, r),
-					((omero.grid.LongColumn) cols[c]).values[r]);
-			}
-		}
-	}
-
-	@Test
-	public void downloadDoubleTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[2];
-		final omero.grid.DoubleColumn dOne = new omero.grid.DoubleColumn();
-		dOne.name = "Header 1";
-		dOne.values = new double[] { 0.125, -0.5, 923014712408917.25, -241.03125,
-			0.0 };
-		final omero.grid.DoubleColumn dTwo = new omero.grid.DoubleColumn();
-		dTwo.name = "Header 2";
-		dTwo.values = new double[] { 1002.125, 908082.5, 59871249.0625, -7.25,
-			4.5 };
-		cols[0] = dOne;
-		cols[1] = dTwo;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1 }, 5);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(ResultsTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 2);
-		assertEquals(imageJTable.getRowCount(), 5);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertEquals(((ResultsTable) imageJTable).getValue(c, r),
-					((omero.grid.DoubleColumn) cols[c]).values[r], 0);
-			}
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	@Test
-	public void downloadLongArrayTable(
-		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[2];
-		final omero.grid.LongArrayColumn laOne = new omero.grid.LongArrayColumn();
-		laOne.name = "Header 1";
-		laOne.values = new long[][] { { 0l, -9223372036854775808l }, { 134l,
-			9223372036854775807l } };
-		final omero.grid.LongArrayColumn laTwo = new omero.grid.LongArrayColumn();
-		laTwo.name = "Header 2";
-		laTwo.values = new long[][] { { -2139847, 1023894 }, { 12, 23415 } };
-		cols[0] = laOne;
-		cols[1] = laTwo;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1 }, 2);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(GenericTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 2);
-		assertEquals(imageJTable.getRowCount(), 2);
-		assertEquals(imageJTable.get(0).size(), 2);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
-				assertTrue(imageJTable.get(c).getType() == LongArray.class);
-				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c)).get(r)
-					.getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
-			}
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	@Test
-	public void downloadStringTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[3];
-		final omero.grid.StringColumn sOne = new omero.grid.StringColumn();
-		sOne.name = "Header 1";
-		sOne.values = new String[] { "abc", "123", "hi!" };
-		final omero.grid.StringColumn sTwo = new omero.grid.StringColumn();
-		sTwo.name = "Header 2";
-		sTwo.values = new String[] { "Good Morning", "Good evening", "good night" };
-		final omero.grid.StringColumn sThree = new omero.grid.StringColumn();
-		sThree.name = "Header 3";
-		sThree.values = new String[] { "good afternoon", "hey", "hello." };
-		cols[0] = sOne;
-		cols[1] = sTwo;
-		cols[2] = sThree;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1, 2 }, 3);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(GenericTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 3);
-		assertEquals(imageJTable.getRowCount(), 3);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
-				assertTrue(imageJTable.get(c).getType() == String.class);
-				assertEquals(((DefaultColumn<String>) imageJTable.get(c)).get(r),
-					((omero.grid.StringColumn) cols[c]).values[r]);
-			}
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	@Test
-	public void downloadMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[4];
-		final omero.grid.StringColumn mOne = new omero.grid.StringColumn();
-		mOne.name = "Header 1";
-		mOne.values = new String[] { "abc", "123", "hi!" };
-		final omero.grid.BoolColumn mTwo = new omero.grid.BoolColumn();
-		mTwo.name = "Header 2";
-		mTwo.values = new boolean[] { false, true, false };
-		final omero.grid.DoubleArrayColumn mThree =
-			new omero.grid.DoubleArrayColumn();
-		mThree.name = "Header 3";
-		mThree.values = new double[][] { { 0.125, 3879123.5, -93.25 }, { 0,
-			-123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
-		final omero.grid.LongColumn mFour = new omero.grid.LongColumn();
-		mFour.name = "Header 4";
-		mFour.values = new long[] { -9028131908l, 0, 12 };
-		cols[0] = mOne;
-		cols[1] = mTwo;
-		cols[2] = mThree;
-		cols[3] = mFour;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1, 2, 3 }, 3);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(GenericTable.class.isInstance(imageJTable));
-		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(0)));
-		assertTrue(imageJTable.get(0).getType() == String.class);
-		assertTrue(BoolColumn.class.isInstance(imageJTable.get(1)));
-		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(2)));
-		assertTrue(imageJTable.get(2).getType() == DoubleArray.class);
-		assertTrue(LongColumn.class.isInstance(imageJTable.get(3)));
-
-		assertEquals(imageJTable.getColumnCount(), 4);
-		assertEquals(imageJTable.getRowCount(), 3);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			assertEquals(((DefaultColumn<String>) imageJTable.get(0)).get(r),
-				((omero.grid.StringColumn) cols[0]).values[r]);
-		}
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			assertEquals(((BoolColumn) imageJTable.get(1)).getValue(r),
-				((omero.grid.BoolColumn) cols[1]).values[r]);
-		}
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2)).get(r)
-				.getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r], 0);
-		}
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			assertEquals(((LongColumn) imageJTable.get(3)).getValue(r),
-				((omero.grid.LongColumn) cols[3]).values[r]);
-		}
-	}
-
-	@Test
-	public void downloadRefTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
-		DSOutOfServiceException
-	{
-		// Setup OMERO data structures
-		final omero.grid.Column[] cols = new omero.grid.Column[3];
-		final omero.grid.ImageColumn rOne = new omero.grid.ImageColumn();
-		rOne.name = "Header 1";
-		rOne.values = new long[] { 101, 102, 103 };
-		final omero.grid.ImageColumn rTwo = new omero.grid.ImageColumn();
-		rTwo.name = "Header 2";
-		rTwo.values = new long[] { 201, 202, 203 };
-		final omero.grid.ImageColumn rThree = new omero.grid.ImageColumn();
-		rThree.name = "Header 3";
-		rThree.values = new long[] { 301, 302, 303 };
-		cols[0] = rOne;
-		cols[1] = rTwo;
-		cols[2] = rThree;
-
-		final omero.grid.Data testData = new omero.grid.Data();
-		testData.columns = cols;
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
-			testData, new long[] { 0, 1, 2 }, 3);
-
-		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
-			.downloadTable(credentials, 0);
-
-		// Verify method calls occurred in expected order
-		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
-
-		// Tests
-		assertTrue(GenericTable.class.isInstance(imageJTable));
-		assertEquals(imageJTable.getColumnCount(), 3);
-		assertEquals(imageJTable.getRowCount(), 3);
-
-		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
-		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
-		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
-
-		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
-				assertTrue(OMERORefColumn.class.isInstance(imageJTable.get(c)));
-				assertTrue(imageJTable.get(c).getType() == Long.class);
-				assertEquals(((OMERORefColumn) imageJTable.get(c)).getOMERORef(),
-					OMERORef.IMAGE);
-				assertEquals(((OMERORefColumn) imageJTable.get(c)).get(r).longValue(),
-					((omero.grid.ImageColumn) cols[c]).values[r]);
-			}
-		}
-	}
-
-	// -- Helper methods --
-
-	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-		final Gateway gatewayMock, final SecurityContext scMock,
-		final SharedResourcesPrx srMock, final TablePrx tableMock,
-		final omero.grid.Column[] cols, final omero.grid.Data testData,
-		final long[] ind, final int rows) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		DSOutOfServiceException
-	{
-		new NonStrictExpectations() {
-
-			{
-				// Expect constructors
-				new DefaultOMEROSession(withNotNull());
-				new OriginalFileI(anyLong, false);
-
-				sessionMock.getGateway();
-				result = gatewayMock;
-				sessionMock.getSecurityContext();
-				result = scMock;
-				gatewayMock.getSharedResources(scMock);
-				result = srMock;
-				srMock.openTable((OriginalFile) any);
-				result = tableMock;
-
-				tableMock.getNumberOfRows();
-				result = rows;
-
-				tableMock.getHeaders();
-				result = cols;
-
-				tableMock.getHeaders();
-				result = cols;
-
-				tableMock.read(ind, 0, rows);
-				result = testData;
-
-				tableMock.close();
-			}
-		};
-	}
-
-	private void verify(final DefaultOMEROSession sessionMock,
-		final Gateway gatewayMock, final SecurityContext scMock,
-		final SharedResourcesPrx srMock, final TablePrx tableMock)
-		throws ServerError, DSOutOfServiceException
-	{
-		new VerificationsInOrder() {
-
-			{
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.openTable((OriginalFile) any);
-				tableMock.getNumberOfRows();
-				tableMock.getHeaders();
-				tableMock.getHeaders();
-				tableMock.read((long[]) any, anyLong, anyLong);
-				tableMock.close();
-			}
-		};
-	}
+//	@Test
+//	public void downloadBoolTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[3];
+//		final omero.grid.BoolColumn bOne = new omero.grid.BoolColumn();
+//		bOne.name = "Header 1";
+//		bOne.values = new boolean[] { true, true, true, true, false, false, false,
+//			false };
+//		final omero.grid.BoolColumn bTwo = new omero.grid.BoolColumn();
+//		bTwo.name = "Header 2";
+//		bTwo.values = new boolean[] { true, true, false, false, true, true, false,
+//			false };
+//		final omero.grid.BoolColumn bThree = new omero.grid.BoolColumn();
+//		bThree.name = "Header 3";
+//		bThree.values = new boolean[] { true, false, true, false, true, false, true,
+//			false };
+//		cols[0] = bOne;
+//		cols[1] = bTwo;
+//		cols[2] = bThree;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1, 2 }, 8);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(BoolTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 3);
+//		assertEquals(imageJTable.getRowCount(), 8);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertEquals(((BoolTable) imageJTable).getValue(c, r),
+//					((omero.grid.BoolColumn) cols[c]).values[r]);
+//			}
+//		}
+//	}
+//
+//	@Test
+//	public void downloadLongTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[4];
+//		final omero.grid.LongColumn lOne = new omero.grid.LongColumn();
+//		lOne.name = "Header 1";
+//		lOne.values = new long[] { 0l, -9223372036854775808l,
+//			9223372036854775807l };
+//		final omero.grid.LongColumn lTwo = new omero.grid.LongColumn();
+//		lTwo.name = "Header 2";
+//		lTwo.values = new long[] { 134l, 5415145l, 4775807l };
+//		final omero.grid.LongColumn lThree = new omero.grid.LongColumn();
+//		lThree.name = "Header 3";
+//		lThree.values = new long[] { -1898l, -97234l, 75807l };
+//		final omero.grid.LongColumn lFour = new omero.grid.LongColumn();
+//		lFour.name = "Header 4";
+//		lFour.values = new long[] { 19048l, -123l, 4l };
+//		cols[0] = lOne;
+//		cols[1] = lTwo;
+//		cols[2] = lThree;
+//		cols[3] = lFour;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1, 2, 3 }, 3);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(LongTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 4);
+//		assertEquals(imageJTable.getRowCount(), 3);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+//		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertEquals(((LongTable) imageJTable).getValue(c, r),
+//					((omero.grid.LongColumn) cols[c]).values[r]);
+//			}
+//		}
+//	}
+//
+//	@Test
+//	public void downloadDoubleTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[2];
+//		final omero.grid.DoubleColumn dOne = new omero.grid.DoubleColumn();
+//		dOne.name = "Header 1";
+//		dOne.values = new double[] { 0.125, -0.5, 923014712408917.25, -241.03125,
+//			0.0 };
+//		final omero.grid.DoubleColumn dTwo = new omero.grid.DoubleColumn();
+//		dTwo.name = "Header 2";
+//		dTwo.values = new double[] { 1002.125, 908082.5, 59871249.0625, -7.25,
+//			4.5 };
+//		cols[0] = dOne;
+//		cols[1] = dTwo;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1 }, 5);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(ResultsTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 2);
+//		assertEquals(imageJTable.getRowCount(), 5);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertEquals(((ResultsTable) imageJTable).getValue(c, r),
+//					((omero.grid.DoubleColumn) cols[c]).values[r], 0);
+//			}
+//		}
+//	}
+//
+//	@SuppressWarnings("unchecked")
+//	@Test
+//	public void downloadLongArrayTable(
+//		@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[2];
+//		final omero.grid.LongArrayColumn laOne = new omero.grid.LongArrayColumn();
+//		laOne.name = "Header 1";
+//		laOne.values = new long[][] { { 0l, -9223372036854775808l }, { 134l,
+//			9223372036854775807l } };
+//		final omero.grid.LongArrayColumn laTwo = new omero.grid.LongArrayColumn();
+//		laTwo.name = "Header 2";
+//		laTwo.values = new long[][] { { -2139847, 1023894 }, { 12, 23415 } };
+//		cols[0] = laOne;
+//		cols[1] = laTwo;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1 }, 2);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(GenericTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 2);
+//		assertEquals(imageJTable.getRowCount(), 2);
+//		assertEquals(imageJTable.get(0).size(), 2);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+//				assertTrue(imageJTable.get(c).getType() == LongArray.class);
+//				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c)).get(r)
+//					.getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
+//			}
+//		}
+//	}
+//
+//	@SuppressWarnings("unchecked")
+//	@Test
+//	public void downloadStringTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[3];
+//		final omero.grid.StringColumn sOne = new omero.grid.StringColumn();
+//		sOne.name = "Header 1";
+//		sOne.values = new String[] { "abc", "123", "hi!" };
+//		final omero.grid.StringColumn sTwo = new omero.grid.StringColumn();
+//		sTwo.name = "Header 2";
+//		sTwo.values = new String[] { "Good Morning", "Good evening", "good night" };
+//		final omero.grid.StringColumn sThree = new omero.grid.StringColumn();
+//		sThree.name = "Header 3";
+//		sThree.values = new String[] { "good afternoon", "hey", "hello." };
+//		cols[0] = sOne;
+//		cols[1] = sTwo;
+//		cols[2] = sThree;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1, 2 }, 3);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(GenericTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 3);
+//		assertEquals(imageJTable.getRowCount(), 3);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+//				assertTrue(imageJTable.get(c).getType() == String.class);
+//				assertEquals(((DefaultColumn<String>) imageJTable.get(c)).get(r),
+//					((omero.grid.StringColumn) cols[c]).values[r]);
+//			}
+//		}
+//	}
+//
+//	@SuppressWarnings("unchecked")
+//	@Test
+//	public void downloadMixedTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[4];
+//		final omero.grid.StringColumn mOne = new omero.grid.StringColumn();
+//		mOne.name = "Header 1";
+//		mOne.values = new String[] { "abc", "123", "hi!" };
+//		final omero.grid.BoolColumn mTwo = new omero.grid.BoolColumn();
+//		mTwo.name = "Header 2";
+//		mTwo.values = new boolean[] { false, true, false };
+//		final omero.grid.DoubleArrayColumn mThree =
+//			new omero.grid.DoubleArrayColumn();
+//		mThree.name = "Header 3";
+//		mThree.values = new double[][] { { 0.125, 3879123.5, -93.25 }, { 0,
+//			-123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
+//		final omero.grid.LongColumn mFour = new omero.grid.LongColumn();
+//		mFour.name = "Header 4";
+//		mFour.values = new long[] { -9028131908l, 0, 12 };
+//		cols[0] = mOne;
+//		cols[1] = mTwo;
+//		cols[2] = mThree;
+//		cols[3] = mFour;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1, 2, 3 }, 3);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(GenericTable.class.isInstance(imageJTable));
+//		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(0)));
+//		assertTrue(imageJTable.get(0).getType() == String.class);
+//		assertTrue(BoolColumn.class.isInstance(imageJTable.get(1)));
+//		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(2)));
+//		assertTrue(imageJTable.get(2).getType() == DoubleArray.class);
+//		assertTrue(LongColumn.class.isInstance(imageJTable.get(3)));
+//
+//		assertEquals(imageJTable.getColumnCount(), 4);
+//		assertEquals(imageJTable.getRowCount(), 3);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+//		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			assertEquals(((DefaultColumn<String>) imageJTable.get(0)).get(r),
+//				((omero.grid.StringColumn) cols[0]).values[r]);
+//		}
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			assertEquals(((BoolColumn) imageJTable.get(1)).getValue(r),
+//				((omero.grid.BoolColumn) cols[1]).values[r]);
+//		}
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2)).get(r)
+//				.getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r], 0);
+//		}
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			assertEquals(((LongColumn) imageJTable.get(3)).getValue(r),
+//				((omero.grid.LongColumn) cols[3]).values[r]);
+//		}
+//	}
+//
+//	@Test
+//	public void downloadRefTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+//		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+//		DSOutOfServiceException
+//	{
+//		// Setup OMERO data structures
+//		final omero.grid.Column[] cols = new omero.grid.Column[3];
+//		final omero.grid.ImageColumn rOne = new omero.grid.ImageColumn();
+//		rOne.name = "Header 1";
+//		rOne.values = new long[] { 101, 102, 103 };
+//		final omero.grid.ImageColumn rTwo = new omero.grid.ImageColumn();
+//		rTwo.name = "Header 2";
+//		rTwo.values = new long[] { 201, 202, 203 };
+//		final omero.grid.ImageColumn rThree = new omero.grid.ImageColumn();
+//		rThree.name = "Header 3";
+//		rThree.values = new long[] { 301, 302, 303 };
+//		cols[0] = rOne;
+//		cols[1] = rTwo;
+//		cols[2] = rThree;
+//
+//		final omero.grid.Data testData = new omero.grid.Data();
+//		testData.columns = cols;
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
+//			testData, new long[] { 0, 1, 2 }, 3);
+//
+//		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+//			.downloadTable(credentials, 0);
+//
+//		// Verify method calls occurred in expected order
+//		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
+//
+//		// Tests
+//		assertTrue(GenericTable.class.isInstance(imageJTable));
+//		assertEquals(imageJTable.getColumnCount(), 3);
+//		assertEquals(imageJTable.getRowCount(), 3);
+//
+//		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+//		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+//		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+//
+//		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+//			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+//				assertTrue(OMERORefColumn.class.isInstance(imageJTable.get(c)));
+//				assertTrue(imageJTable.get(c).getType() == Long.class);
+//				assertEquals(((OMERORefColumn) imageJTable.get(c)).getOMERORef(),
+//					OMERORef.IMAGE);
+//				assertEquals(((OMERORefColumn) imageJTable.get(c)).get(r).longValue(),
+//					((omero.grid.ImageColumn) cols[c]).values[r]);
+//			}
+//		}
+//	}
+//
+//	// -- Helper methods --
+//
+//	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
+//		final Gateway gatewayMock, final SecurityContext scMock,
+//		final SharedResourcesPrx srMock, final TablePrx tableMock,
+//		final omero.grid.Column[] cols, final omero.grid.Data testData,
+//		final long[] ind, final int rows) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException,
+//		DSOutOfServiceException
+//	{
+//		new NonStrictExpectations() {
+//
+//			{
+//				// Expect constructors
+//				new DefaultOMEROSession(withNotNull());
+//				new OriginalFileI(anyLong, false);
+//
+//				sessionMock.getGateway();
+//				result = gatewayMock;
+//				sessionMock.getSecurityContext();
+//				result = scMock;
+//				gatewayMock.getSharedResources(scMock);
+//				result = srMock;
+//				srMock.openTable((OriginalFile) any);
+//				result = tableMock;
+//
+//				tableMock.getNumberOfRows();
+//				result = rows;
+//
+//				tableMock.getHeaders();
+//				result = cols;
+//
+//				tableMock.getHeaders();
+//				result = cols;
+//
+//				tableMock.read(ind, 0, rows);
+//				result = testData;
+//
+//				tableMock.close();
+//			}
+//		};
+//	}
+//
+//	private void verify(final DefaultOMEROSession sessionMock,
+//		final Gateway gatewayMock, final SecurityContext scMock,
+//		final SharedResourcesPrx srMock, final TablePrx tableMock)
+//		throws ServerError, DSOutOfServiceException
+//	{
+//		new VerificationsInOrder() {
+//
+//			{
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.openTable((OriginalFile) any);
+//				tableMock.getNumberOfRows();
+//				tableMock.getHeaders();
+//				tableMock.getHeaders();
+//				tableMock.read((long[]) any, anyLong, anyLong);
+//				tableMock.close();
+//			}
+//		};
+//	}
 }

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -533,7 +533,6 @@ public class DownloadTableTest {
 				result = testData;
 
 				tableMock.close();
-				sessionMock.close();
 			}
 		};
 	}
@@ -554,7 +553,6 @@ public class DownloadTableTest {
 				tableMock.getHeaders();
 				tableMock.read((long[]) any, anyLong, anyLong);
 				tableMock.close();
-				sessionMock.close();
 			}
 		};
 	}

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -28,11 +28,7 @@ package net.imagej.omero;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
-import mockit.Mocked;
-import mockit.NonStrictExpectations;
-import mockit.VerificationsInOrder;
+
 import net.imagej.table.BoolColumn;
 import net.imagej.table.BoolTable;
 import net.imagej.table.DefaultColumn;
@@ -41,12 +37,6 @@ import net.imagej.table.LongColumn;
 import net.imagej.table.LongTable;
 import net.imagej.table.ResultsTable;
 import net.imagej.table.Table;
-import omero.ServerError;
-import omero.api.ServiceFactoryPrx;
-import omero.grid.SharedResourcesPrx;
-import omero.grid.TablePrx;
-import omero.model.OriginalFile;
-import omero.model.OriginalFileI;
 
 import org.junit.After;
 import org.junit.Before;
@@ -54,6 +44,20 @@ import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.util.DoubleArray;
 import org.scijava.util.LongArray;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.VerificationsInOrder;
+import omero.ServerError;
+import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.grid.SharedResourcesPrx;
+import omero.grid.TablePrx;
+import omero.model.OriginalFile;
+import omero.model.OriginalFileI;
 
 /**
  * Tests {@link DefaultOMEROService#downloadTable(OMEROCredentials, long)}.
@@ -80,25 +84,25 @@ public class DownloadTableTest {
 
 	@Test
 	public void downloadBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[3];
 		final omero.grid.BoolColumn bOne = new omero.grid.BoolColumn();
 		bOne.name = "Header 1";
-		bOne.values =
-			new boolean[] { true, true, true, true, false, false, false, false };
+		bOne.values = new boolean[] { true, true, true, true, false, false, false,
+			false };
 		final omero.grid.BoolColumn bTwo = new omero.grid.BoolColumn();
 		bTwo.name = "Header 2";
-		bTwo.values =
-			new boolean[] { true, true, false, false, true, true, false, false };
+		bTwo.values = new boolean[] { true, true, false, false, true, true, false,
+			false };
 		final omero.grid.BoolColumn bThree = new omero.grid.BoolColumn();
 		bThree.name = "Header 3";
-		bThree.values =
-			new boolean[] { true, false, true, false, true, false, true, false };
+		bThree.values = new boolean[] { true, false, true, false, true, false, true,
+			false };
 		cols[0] = bOne;
 		cols[1] = bTwo;
 		cols[2] = bThree;
@@ -108,14 +112,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1, 2 }, 8);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(BoolTable.class.isInstance(imageJTable));
@@ -136,17 +140,17 @@ public class DownloadTableTest {
 
 	@Test
 	public void downloadLongTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[4];
 		final omero.grid.LongColumn lOne = new omero.grid.LongColumn();
 		lOne.name = "Header 1";
-		lOne.values =
-			new long[] { 0l, -9223372036854775808l, 9223372036854775807l };
+		lOne.values = new long[] { 0l, -9223372036854775808l,
+			9223372036854775807l };
 		final omero.grid.LongColumn lTwo = new omero.grid.LongColumn();
 		lTwo.name = "Header 2";
 		lTwo.values = new long[] { 134l, 5415145l, 4775807l };
@@ -166,14 +170,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1, 2, 3 }, 3);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(LongTable.class.isInstance(imageJTable));
@@ -194,23 +198,22 @@ public class DownloadTableTest {
 	}
 
 	@Test
-	public void downloadDoubleTable(
-		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+	public void downloadDoubleTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[2];
 		final omero.grid.DoubleColumn dOne = new omero.grid.DoubleColumn();
 		dOne.name = "Header 1";
-		dOne.values =
-			new double[] { 0.125, -0.5, 923014712408917.25, -241.03125, 0.0 };
+		dOne.values = new double[] { 0.125, -0.5, 923014712408917.25, -241.03125,
+			0.0 };
 		final omero.grid.DoubleColumn dTwo = new omero.grid.DoubleColumn();
 		dTwo.name = "Header 2";
-		dTwo.values =
-			new double[] { 1002.125, 908082.5, 59871249.0625, -7.25, 4.5 };
+		dTwo.values = new double[] { 1002.125, 908082.5, 59871249.0625, -7.25,
+			4.5 };
 		cols[0] = dOne;
 		cols[1] = dTwo;
 
@@ -219,14 +222,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1 }, 5);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(ResultsTable.class.isInstance(imageJTable));
@@ -248,18 +251,17 @@ public class DownloadTableTest {
 	@Test
 	public void downloadLongArrayTable(
 		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[2];
 		final omero.grid.LongArrayColumn laOne = new omero.grid.LongArrayColumn();
 		laOne.name = "Header 1";
-		laOne.values =
-			new long[][] { { 0l, -9223372036854775808l },
-				{ 134l, 9223372036854775807l } };
+		laOne.values = new long[][] { { 0l, -9223372036854775808l }, { 134l,
+			9223372036854775807l } };
 		final omero.grid.LongArrayColumn laTwo = new omero.grid.LongArrayColumn();
 		laTwo.name = "Header 2";
 		laTwo.values = new long[][] { { -2139847, 1023894 }, { 12, 23415 } };
@@ -271,14 +273,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1 }, 2);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(GenericTable.class.isInstance(imageJTable));
@@ -293,20 +295,19 @@ public class DownloadTableTest {
 			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
 				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
 				assertTrue(imageJTable.get(c).getType() == LongArray.class);
-				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c))
-					.get(r).getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
+				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c)).get(r)
+					.getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
 			}
 		}
 	}
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void downloadStringTable(
-		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+	public void downloadStringTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[3];
@@ -328,14 +329,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1, 2 }, 3);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(GenericTable.class.isInstance(imageJTable));
@@ -359,10 +360,10 @@ public class DownloadTableTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void downloadMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[4];
@@ -375,9 +376,8 @@ public class DownloadTableTest {
 		final omero.grid.DoubleArrayColumn mThree =
 			new omero.grid.DoubleArrayColumn();
 		mThree.name = "Header 3";
-		mThree.values =
-			new double[][] { { 0.125, 3879123.5, -93.25 },
-				{ 0, -123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
+		mThree.values = new double[][] { { 0.125, 3879123.5, -93.25 }, { 0,
+			-123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
 		final omero.grid.LongColumn mFour = new omero.grid.LongColumn();
 		mFour.name = "Header 4";
 		mFour.values = new long[] { -9028131908l, 0, 12 };
@@ -391,14 +391,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1, 2, 3 }, 3);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(GenericTable.class.isInstance(imageJTable));
@@ -428,9 +428,8 @@ public class DownloadTableTest {
 		}
 
 		for (int r = 0; r < imageJTable.getRowCount(); r++) {
-			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2))
-				.get(r).getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r],
-				0);
+			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2)).get(r)
+				.getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r], 0);
 		}
 
 		for (int r = 0; r < imageJTable.getRowCount(); r++) {
@@ -441,10 +440,10 @@ public class DownloadTableTest {
 
 	@Test
 	public void downloadRefTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
-		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError,
+		DSOutOfServiceException
 	{
 		// Setup OMERO data structures
 		final omero.grid.Column[] cols = new omero.grid.Column[3];
@@ -466,14 +465,14 @@ public class DownloadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock, cols,
 			testData, new long[] { 0, 1, 2 }, 3);
 
-		final Table<?, ?> imageJTable =
-			((DefaultOMEROService) service).downloadTable(credentials, 0);
+		final Table<?, ?> imageJTable = ((DefaultOMEROService) service)
+			.downloadTable(credentials, 0);
 
 		// Verify method calls occurred in expected order
-		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+		verify(sessionMock, gatewayMock, scMock, srMock, tableMock);
 
 		// Tests
 		assertTrue(GenericTable.class.isInstance(imageJTable));
@@ -499,23 +498,25 @@ public class DownloadTableTest {
 	// -- Helper methods --
 
 	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-		final omero.client clientMock, final ServiceFactoryPrx sfMock,
+		final Gateway gatewayMock, final SecurityContext scMock,
 		final SharedResourcesPrx srMock, final TablePrx tableMock,
 		final omero.grid.Column[] cols, final omero.grid.Data testData,
 		final long[] ind, final int rows) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException
+		PermissionDeniedException, CannotCreateSessionException,
+		DSOutOfServiceException
 	{
 		new NonStrictExpectations() {
+
 			{
 				// Expect constructors
 				new DefaultOMEROSession(withNotNull());
 				new OriginalFileI(anyLong, false);
 
-				sessionMock.getClient();
-				result = clientMock;
-				clientMock.getSession();
-				result = sfMock;
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				result = gatewayMock;
+				sessionMock.getSecurityContext();
+				result = scMock;
+				gatewayMock.getSharedResources(scMock);
 				result = srMock;
 				srMock.openTable((OriginalFile) any);
 				result = tableMock;
@@ -538,15 +539,16 @@ public class DownloadTableTest {
 	}
 
 	private void verify(final DefaultOMEROSession sessionMock,
-		final omero.client clientMock, final ServiceFactoryPrx sfMock,
+		final Gateway gatewayMock, final SecurityContext scMock,
 		final SharedResourcesPrx srMock, final TablePrx tableMock)
-		throws ServerError
+		throws ServerError, DSOutOfServiceException
 	{
 		new VerificationsInOrder() {
+
 			{
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.openTable((OriginalFile) any);
 				tableMock.getNumberOfRows();
 				tableMock.getHeaders();

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -1,0 +1,561 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.VerificationsInOrder;
+import net.imagej.table.BoolColumn;
+import net.imagej.table.BoolTable;
+import net.imagej.table.DefaultColumn;
+import net.imagej.table.GenericTable;
+import net.imagej.table.LongColumn;
+import net.imagej.table.LongTable;
+import net.imagej.table.ResultsTable;
+import net.imagej.table.Table;
+import omero.ServerError;
+import omero.api.ServiceFactoryPrx;
+import omero.grid.SharedResourcesPrx;
+import omero.grid.TablePrx;
+import omero.model.OriginalFile;
+import omero.model.OriginalFileI;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.util.DoubleArray;
+import org.scijava.util.LongArray;
+
+/**
+ * Tests {@link DefaultOMEROService#downloadTable(OMEROCredentials, long)}.
+ *
+ * @author Alison Walter
+ */
+public class DownloadTableTest {
+
+	private OMEROService service;
+	private OMEROCredentials credentials;
+
+	@Before
+	public void setUp() throws Exception {
+		service = new Context(OMEROService.class).service(OMEROService.class);
+	}
+
+	@After
+	public void tearDown() {
+		if (service != null) {
+			service.getContext().dispose();
+			service = null;
+		}
+	}
+
+	@Test
+	public void downloadBoolTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[3];
+		final omero.grid.BoolColumn bOne = new omero.grid.BoolColumn();
+		bOne.name = "Header 1";
+		bOne.values =
+			new boolean[] { true, true, true, true, false, false, false, false };
+		final omero.grid.BoolColumn bTwo = new omero.grid.BoolColumn();
+		bTwo.name = "Header 2";
+		bTwo.values =
+			new boolean[] { true, true, false, false, true, true, false, false };
+		final omero.grid.BoolColumn bThree = new omero.grid.BoolColumn();
+		bThree.name = "Header 3";
+		bThree.values =
+			new boolean[] { true, false, true, false, true, false, true, false };
+		cols[0] = bOne;
+		cols[1] = bTwo;
+		cols[2] = bThree;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1, 2 }, 8);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(BoolTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 8);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals(((BoolTable) imageJTable).getValue(c, r),
+					((omero.grid.BoolColumn) cols[c]).values[r]);
+			}
+		}
+	}
+
+	@Test
+	public void downloadLongTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[4];
+		final omero.grid.LongColumn lOne = new omero.grid.LongColumn();
+		lOne.name = "Header 1";
+		lOne.values =
+			new long[] { 0l, -9223372036854775808l, 9223372036854775807l };
+		final omero.grid.LongColumn lTwo = new omero.grid.LongColumn();
+		lTwo.name = "Header 2";
+		lTwo.values = new long[] { 134l, 5415145l, 4775807l };
+		final omero.grid.LongColumn lThree = new omero.grid.LongColumn();
+		lThree.name = "Header 3";
+		lThree.values = new long[] { -1898l, -97234l, 75807l };
+		final omero.grid.LongColumn lFour = new omero.grid.LongColumn();
+		lFour.name = "Header 4";
+		lFour.values = new long[] { 19048l, -123l, 4l };
+		cols[0] = lOne;
+		cols[1] = lTwo;
+		cols[2] = lThree;
+		cols[3] = lFour;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1, 2, 3 }, 3);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(LongTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 4);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals(((LongTable) imageJTable).getValue(c, r),
+					((omero.grid.LongColumn) cols[c]).values[r]);
+			}
+		}
+	}
+
+	@Test
+	public void downloadDoubleTable(
+		@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[2];
+		final omero.grid.DoubleColumn dOne = new omero.grid.DoubleColumn();
+		dOne.name = "Header 1";
+		dOne.values =
+			new double[] { 0.125, -0.5, 923014712408917.25, -241.03125, 0.0 };
+		final omero.grid.DoubleColumn dTwo = new omero.grid.DoubleColumn();
+		dTwo.name = "Header 2";
+		dTwo.values =
+			new double[] { 1002.125, 908082.5, 59871249.0625, -7.25, 4.5 };
+		cols[0] = dOne;
+		cols[1] = dTwo;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1 }, 5);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(ResultsTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 2);
+		assertEquals(imageJTable.getRowCount(), 5);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertEquals(((ResultsTable) imageJTable).getValue(c, r),
+					((omero.grid.DoubleColumn) cols[c]).values[r], 0);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void downloadLongArrayTable(
+		@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[2];
+		final omero.grid.LongArrayColumn laOne = new omero.grid.LongArrayColumn();
+		laOne.name = "Header 1";
+		laOne.values =
+			new long[][] { { 0l, -9223372036854775808l },
+				{ 134l, 9223372036854775807l } };
+		final omero.grid.LongArrayColumn laTwo = new omero.grid.LongArrayColumn();
+		laTwo.name = "Header 2";
+		laTwo.values = new long[][] { { -2139847, 1023894 }, { 12, 23415 } };
+		cols[0] = laOne;
+		cols[1] = laTwo;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1 }, 2);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 2);
+		assertEquals(imageJTable.getRowCount(), 2);
+		assertEquals(imageJTable.get(0).size(), 2);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == LongArray.class);
+				assertArrayEquals(((DefaultColumn<LongArray>) imageJTable.get(c))
+					.get(r).getArray(), ((omero.grid.LongArrayColumn) cols[c]).values[r]);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void downloadStringTable(
+		@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[3];
+		final omero.grid.StringColumn sOne = new omero.grid.StringColumn();
+		sOne.name = "Header 1";
+		sOne.values = new String[] { "abc", "123", "hi!" };
+		final omero.grid.StringColumn sTwo = new omero.grid.StringColumn();
+		sTwo.name = "Header 2";
+		sTwo.values = new String[] { "Good Morning", "Good evening", "good night" };
+		final omero.grid.StringColumn sThree = new omero.grid.StringColumn();
+		sThree.name = "Header 3";
+		sThree.values = new String[] { "good afternoon", "hey", "hello." };
+		cols[0] = sOne;
+		cols[1] = sTwo;
+		cols[2] = sThree;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1, 2 }, 3);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(DefaultColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == String.class);
+				assertEquals(((DefaultColumn<String>) imageJTable.get(c)).get(r),
+					((omero.grid.StringColumn) cols[c]).values[r]);
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void downloadMixedTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[4];
+		final omero.grid.StringColumn mOne = new omero.grid.StringColumn();
+		mOne.name = "Header 1";
+		mOne.values = new String[] { "abc", "123", "hi!" };
+		final omero.grid.BoolColumn mTwo = new omero.grid.BoolColumn();
+		mTwo.name = "Header 2";
+		mTwo.values = new boolean[] { false, true, false };
+		final omero.grid.DoubleArrayColumn mThree =
+			new omero.grid.DoubleArrayColumn();
+		mThree.name = "Header 3";
+		mThree.values =
+			new double[][] { { 0.125, 3879123.5, -93.25 },
+				{ 0, -123353.03125, -5.5 }, { 100.25, 0.125, -9000.5 } };
+		final omero.grid.LongColumn mFour = new omero.grid.LongColumn();
+		mFour.name = "Header 4";
+		mFour.values = new long[] { -9028131908l, 0, 12 };
+		cols[0] = mOne;
+		cols[1] = mTwo;
+		cols[2] = mThree;
+		cols[3] = mFour;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1, 2, 3 }, 3);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(0)));
+		assertTrue(imageJTable.get(0).getType() == String.class);
+		assertTrue(BoolColumn.class.isInstance(imageJTable.get(1)));
+		assertTrue(DefaultColumn.class.isInstance(imageJTable.get(2)));
+		assertTrue(imageJTable.get(2).getType() == DoubleArray.class);
+		assertTrue(LongColumn.class.isInstance(imageJTable.get(3)));
+
+		assertEquals(imageJTable.getColumnCount(), 4);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+		assertEquals(imageJTable.getColumnHeader(3), "Header 4");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			assertEquals(((DefaultColumn<String>) imageJTable.get(0)).get(r),
+				((omero.grid.StringColumn) cols[0]).values[r]);
+		}
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			assertEquals(((BoolColumn) imageJTable.get(1)).getValue(r),
+				((omero.grid.BoolColumn) cols[1]).values[r]);
+		}
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			assertArrayEquals(((DefaultColumn<DoubleArray>) imageJTable.get(2))
+				.get(r).getArray(), ((omero.grid.DoubleArrayColumn) cols[2]).values[r],
+				0);
+		}
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			assertEquals(((LongColumn) imageJTable.get(3)).getValue(r),
+				((omero.grid.LongColumn) cols[3]).values[r]);
+		}
+	}
+
+	@Test
+	public void downloadRefTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock)
+		throws PermissionDeniedException, CannotCreateSessionException, ServerError
+	{
+		// Setup OMERO data structures
+		final omero.grid.Column[] cols = new omero.grid.Column[3];
+		final omero.grid.ImageColumn rOne = new omero.grid.ImageColumn();
+		rOne.name = "Header 1";
+		rOne.values = new long[] { 101, 102, 103 };
+		final omero.grid.ImageColumn rTwo = new omero.grid.ImageColumn();
+		rTwo.name = "Header 2";
+		rTwo.values = new long[] { 201, 202, 203 };
+		final omero.grid.ImageColumn rThree = new omero.grid.ImageColumn();
+		rThree.name = "Header 3";
+		rThree.values = new long[] { 301, 302, 303 };
+		cols[0] = rOne;
+		cols[1] = rTwo;
+		cols[2] = rThree;
+
+		final omero.grid.Data testData = new omero.grid.Data();
+		testData.columns = cols;
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock, cols,
+			testData, new long[] { 0, 1, 2 }, 3);
+
+		final Table<?, ?> imageJTable =
+			((DefaultOMEROService) service).downloadTable(credentials, 0);
+
+		// Verify method calls occurred in expected order
+		verify(sessionMock, clientMock, sfMock, srMock, tableMock);
+
+		// Tests
+		assertTrue(GenericTable.class.isInstance(imageJTable));
+		assertEquals(imageJTable.getColumnCount(), 3);
+		assertEquals(imageJTable.getRowCount(), 3);
+
+		assertEquals(imageJTable.getColumnHeader(0), "Header 1");
+		assertEquals(imageJTable.getColumnHeader(1), "Header 2");
+		assertEquals(imageJTable.getColumnHeader(2), "Header 3");
+
+		for (int r = 0; r < imageJTable.getRowCount(); r++) {
+			for (int c = 0; c < imageJTable.getColumnCount(); c++) {
+				assertTrue(OMERORefColumn.class.isInstance(imageJTable.get(c)));
+				assertTrue(imageJTable.get(c).getType() == Long.class);
+				assertEquals(((OMERORefColumn) imageJTable.get(c)).getOMERORef(),
+					OMERORef.IMAGE);
+				assertEquals(((OMERORefColumn) imageJTable.get(c)).get(r).longValue(),
+					((omero.grid.ImageColumn) cols[c]).values[r]);
+			}
+		}
+	}
+
+	// -- Helper methods --
+
+	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
+		final omero.client clientMock, final ServiceFactoryPrx sfMock,
+		final SharedResourcesPrx srMock, final TablePrx tableMock,
+		final omero.grid.Column[] cols, final omero.grid.Data testData,
+		final long[] ind, final int rows) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException
+	{
+		new NonStrictExpectations() {
+			{
+				// Expect constructors
+				new DefaultOMEROSession(withNotNull());
+				new OriginalFileI(anyLong, false);
+
+				sessionMock.getClient();
+				result = clientMock;
+				clientMock.getSession();
+				result = sfMock;
+				sfMock.sharedResources();
+				result = srMock;
+				srMock.openTable((OriginalFile) any);
+				result = tableMock;
+
+				tableMock.getNumberOfRows();
+				result = rows;
+
+				tableMock.getHeaders();
+				result = cols;
+
+				tableMock.getHeaders();
+				result = cols;
+
+				tableMock.read(ind, 0, rows);
+				result = testData;
+
+				tableMock.close();
+				sessionMock.close();
+			}
+		};
+	}
+
+	private void verify(final DefaultOMEROSession sessionMock,
+		final omero.client clientMock, final ServiceFactoryPrx sfMock,
+		final SharedResourcesPrx srMock, final TablePrx tableMock)
+		throws ServerError
+	{
+		new VerificationsInOrder() {
+			{
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.openTable((OriginalFile) any);
+				tableMock.getNumberOfRows();
+				tableMock.getHeaders();
+				tableMock.getHeaders();
+				tableMock.read((long[]) any, anyLong, anyLong);
+				tableMock.close();
+				sessionMock.close();
+			}
+		};
+	}
+}

--- a/src/test/java/net/imagej/omero/DownloadTableTest.java
+++ b/src/test/java/net/imagej/omero/DownloadTableTest.java
@@ -48,7 +48,6 @@ import org.scijava.util.LongArray;
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
 import mockit.Mocked;
-import mockit.NonStrictExpectations;
 import mockit.VerificationsInOrder;
 import omero.ServerError;
 import omero.gateway.Gateway;

--- a/src/test/java/net/imagej/omero/OMEROFormatTest.java
+++ b/src/test/java/net/imagej/omero/OMEROFormatTest.java
@@ -33,8 +33,6 @@ import io.scif.FormatException;
 import io.scif.MetadataService;
 import io.scif.SCIFIO;
 
-import net.imagej.patcher.LegacyInjector;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -45,11 +43,6 @@ import org.junit.Test;
  * @author Curtis Rueden
  */
 public class OMEROFormatTest {
-
-	static {
-		// NB: Necessary to avoid class-loading issues with the patched ImageJ1.
-		LegacyInjector.preinit();
-	}
 
 	private static SCIFIO scifio;
 

--- a/src/test/java/net/imagej/omero/OMEROFormatTest.java
+++ b/src/test/java/net/imagej/omero/OMEROFormatTest.java
@@ -33,8 +33,8 @@ import io.scif.FormatException;
 import io.scif.MetadataService;
 import io.scif.SCIFIO;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -44,15 +44,15 @@ import org.junit.Test;
  */
 public class OMEROFormatTest {
 
-	private static SCIFIO scifio;
+	private SCIFIO scifio;
 
-	@BeforeClass
-	public static void beforeClass() {
+	@Before
+	public void setUp() {
 		scifio = new SCIFIO();
 	}
 
-	@AfterClass
-	public static void afterClass() {
+	@After
+	public void tearDown() {
 		if (scifio != null) scifio.context().dispose();
 	}
 

--- a/src/test/java/net/imagej/omero/OMEROServiceTest.java
+++ b/src/test/java/net/imagej/omero/OMEROServiceTest.java
@@ -26,7 +26,6 @@
 package net.imagej.omero;
 
 import static org.junit.Assert.assertEquals;
-import ij.ImagePlus;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -41,8 +40,6 @@ import java.util.Set;
 import net.imagej.Dataset;
 import net.imagej.display.DatasetView;
 import net.imagej.display.ImageDisplay;
-import net.imagej.patcher.LegacyInjector;
-
 import omero.RArray;
 import omero.RBool;
 import omero.RDouble;
@@ -71,11 +68,6 @@ import org.scijava.util.MersenneTwisterFast;
  * @author Curtis Rueden
  */
 public class OMEROServiceTest {
-
-	static {
-		// NB: Necessary to avoid class-loading issues with the patched ImageJ1.
-		LegacyInjector.preinit();
-	}
 
 	private static OMEROService omeroService;
 
@@ -142,7 +134,6 @@ public class OMEROServiceTest {
 		assertParam(omeroService, RLong.class, Dataset.class);
 		assertParam(omeroService, RLong.class, DatasetView.class);
 		assertParam(omeroService, RLong.class, ImageDisplay.class);
-		assertParam(omeroService, RLong.class, ImagePlus.class);
 
 		// -- test other object types --
 
@@ -205,7 +196,6 @@ public class OMEROServiceTest {
 		assertPrototype(omeroService, RLong.class, Dataset.class);
 		assertPrototype(omeroService, RLong.class, DatasetView.class);
 		assertPrototype(omeroService, RLong.class, ImageDisplay.class);
-		assertPrototype(omeroService, RLong.class, ImagePlus.class);
 
 		// -- test other object types --
 

--- a/src/test/java/net/imagej/omero/OMEROServiceTest.java
+++ b/src/test/java/net/imagej/omero/OMEROServiceTest.java
@@ -53,8 +53,8 @@ import omero.RString;
 import omero.RType;
 import omero.grid.Param;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.scijava.Context;
 import org.scijava.module.AbstractModuleItem;
@@ -69,15 +69,15 @@ import org.scijava.util.MersenneTwisterFast;
  */
 public class OMEROServiceTest {
 
-	private static OMEROService omeroService;
+	private OMEROService omeroService;
 
-	@BeforeClass
-	public static void beforeClass() {
-		omeroService = createService();
+	@Before
+	public void setUp() {
+		omeroService = new Context(OMEROService.class).service(OMEROService.class);
 	}
 
-	@AfterClass
-	public static void afterClass() {
+	@After
+	public void tearDown() {
 		if (omeroService != null) omeroService.getContext().dispose();
 	}
 
@@ -206,10 +206,6 @@ public class OMEROServiceTest {
 	}
 
 	// -- Helper methods --
-
-	private static OMEROService createService() {
-		return new Context(OMEROService.class).service(OMEROService.class);
-	}
 
 	private <T> ModuleItem<T> createItem(final Class<T> type) {
 		return new TestModuleItem<T>(type);

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -28,14 +28,9 @@ package net.imagej.omero;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
 
 import java.util.concurrent.ExecutionException;
 
-import mockit.Mocked;
-import mockit.NonStrictExpectations;
-import mockit.VerificationsInOrder;
 import net.imagej.table.BoolColumn;
 import net.imagej.table.BoolTable;
 import net.imagej.table.CharTable;
@@ -51,13 +46,6 @@ import net.imagej.table.FloatTable;
 import net.imagej.table.GenericTable;
 import net.imagej.table.LongTable;
 import net.imagej.table.ShortTable;
-import omero.ServerError;
-import omero.api.ServiceFactoryPrx;
-import omero.gateway.exception.DSAccessException;
-import omero.gateway.exception.DSOutOfServiceException;
-import omero.grid.SharedResourcesPrx;
-import omero.grid.TablePrx;
-import omero.model.OriginalFile;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,6 +54,20 @@ import org.scijava.Context;
 import org.scijava.util.BoolArray;
 import org.scijava.util.DoubleArray;
 import org.scijava.util.IntArray;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.VerificationsInOrder;
+import omero.ServerError;
+import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.grid.SharedResourcesPrx;
+import omero.grid.TablePrx;
+import omero.model.OriginalFile;
 
 /**
  * Tests {@link DefaultOMEROService#uploadTable}.
@@ -92,12 +94,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final BoolTable table = new DefaultBoolTable(2, 4);
 		table.get(0).fill(new boolean[] { true, true, false, false });
@@ -105,18 +106,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 3l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -145,12 +147,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testShortTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final ShortTable table = new DefaultShortTable(6, 3);
 		table.get(0).fill(new short[] { -32768, 0, 32767 });
@@ -162,18 +163,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 22l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -202,12 +204,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testLongTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final LongTable table = new DefaultLongTable(2, 2);
 		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
@@ -215,18 +216,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 11l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -255,12 +257,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testFloatTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final FloatTable table = new DefaultFloatTable(4, 2);
 		table.get(0).fill(new float[] { -380129.125f, 0.25f });
@@ -276,18 +277,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 21l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -317,18 +319,17 @@ public class UploadTableTest {
 	@Test
 	public void testDoubleArrayTable(
 		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final GenericTable table = new DefaultGenericTable();
-		final DefaultColumn<DoubleArray> ij0 =
-			new DefaultColumn<DoubleArray>(DoubleArray.class, "H1");
-		final DefaultColumn<DoubleArray> ij1 =
-			new DefaultColumn<DoubleArray>(DoubleArray.class, "H2");
+		final DefaultColumn<DoubleArray> ij0 = new DefaultColumn<>(
+			DoubleArray.class, "H1");
+		final DefaultColumn<DoubleArray> ij1 = new DefaultColumn<>(
+			DoubleArray.class, "H2");
 		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
 		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
 		table.add(ij0);
@@ -336,18 +337,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 4l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -381,18 +383,17 @@ public class UploadTableTest {
 
 	@Test
 	public void testBoolArrayTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final GenericTable table = new DefaultGenericTable();
-		final DefaultColumn<BoolArray> ij0 =
-			new DefaultColumn<BoolArray>(BoolArray.class);
-		final DefaultColumn<BoolArray> ij1 =
-			new DefaultColumn<BoolArray>(BoolArray.class);
+		final DefaultColumn<BoolArray> ij0 = new DefaultColumn<>(
+			BoolArray.class);
+		final DefaultColumn<BoolArray> ij1 = new DefaultColumn<>(
+			BoolArray.class);
 
 		ij0.add(new BoolArray(new boolean[] { true, false }));
 		ij0.add(new BoolArray(new boolean[] { false, false }));
@@ -404,18 +405,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 22l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -460,12 +462,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testCharTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final CharTable table = new DefaultCharTable(5, 2);
 		table.get(0).fill(new char[] { 'q', 'V' });
@@ -476,17 +477,18 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 103l);
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -516,12 +518,11 @@ public class UploadTableTest {
 
 	@Test
 	public void testReferenceTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final GenericTable table = new DefaultGenericTable();
 		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
@@ -536,18 +537,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 9l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -576,20 +578,19 @@ public class UploadTableTest {
 
 	@Test
 	public void testMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final omero.client clientMock,
-		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
 		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
 		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		ExecutionException, DSOutOfServiceException, DSAccessException
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
 	{
 		final GenericTable table = new DefaultGenericTable();
 		final BoolColumn ijc0 = new BoolColumn("h0");
 		final DoubleColumn ijc1 = new DoubleColumn("h1");
-		final DefaultColumn<String> ijc2 =
-			new DefaultColumn<String>(String.class, "h2");
-		final DefaultColumn<IntArray> ijc3 =
-			new DefaultColumn<IntArray>(IntArray.class, "h3");
+		final DefaultColumn<String> ijc2 = new DefaultColumn<>(String.class,
+			"h2");
+		final DefaultColumn<IntArray> ijc3 = new DefaultColumn<>(
+			IntArray.class, "h3");
 		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
 		ijc0.fill(new boolean[] { true, false });
 		ijc1.fill(new double[] { 0.03125, -2134.5 });
@@ -606,18 +607,19 @@ public class UploadTableTest {
 
 		// Create expectations
 		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
 			fileMock, 12l);
 
 		final long id = service.uploadTable(credentials, "table", table, 0);
 
 		// Confirm method calls made in this order
 		new VerificationsInOrder() {
+
 			{
 				final omero.grid.Column[] cols;
-				sessionMock.getClient();
-				clientMock.getSession();
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				sessionMock.getSecurityContext();
+				gatewayMock.getSharedResources(scMock);
 				srMock.newTable(anyInt, anyString);
 				tableMock.initialize((omero.grid.Column[]) any);
 				tableMock.addData(cols = withCapture()); // Capture OMERO columns
@@ -683,19 +685,21 @@ public class UploadTableTest {
 	// -- Helper methods --
 
 	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-		final omero.client clientMock, final omero.api.ServiceFactoryPrx sfMock,
+		final Gateway gatewayMock, final SecurityContext scMock,
 		final omero.grid.SharedResourcesPrx srMock, final TablePrx tableMock,
 		final OriginalFile fileMock, final long tableID) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException
+		PermissionDeniedException, CannotCreateSessionException,
+		DSOutOfServiceException
 	{
 		new NonStrictExpectations() {
+
 			{
 				new DefaultOMEROSession(withNotNull());
-				sessionMock.getClient();
-				result = clientMock;
-				clientMock.getSession();
-				result = sfMock;
-				sfMock.sharedResources();
+				sessionMock.getGateway();
+				result = gatewayMock;
+				sessionMock.getSecurityContext();
+				result = scMock;
+				gatewayMock.getSharedResources(scMock);
 				result = srMock;
 				srMock.newTable(1, "table");
 				result = tableMock;

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -92,628 +92,628 @@ public class UploadTableTest {
 		}
 	}
 
-	@Test
-	public void testBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final BoolTable table = new DefaultBoolTable(2, 4);
-		table.get(0).fill(new boolean[] { true, true, false, false });
-		table.get(1).fill(new boolean[] { true, false, true, false });
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 3l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 3l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.BoolColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.BoolColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(cols[c].name, String.valueOf(c));
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.BoolColumn) cols[c]).values[r], table
-							.getValue(c, r));
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testShortTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final ShortTable table = new DefaultShortTable(6, 3);
-		table.get(0).fill(new short[] { -32768, 0, 32767 });
-		table.get(1).fill(new short[] { 12, -12, 5 });
-		table.get(2).fill(new short[] { 10000, 20000, -30000 });
-		table.get(3).fill(new short[] { 1111, 2222, 8888 });
-		table.get(4).fill(new short[] { -4, -17, -31194 });
-		table.get(5).fill(new short[] { 0, 17239, -20 });
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 22l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 22l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(cols[c].name, String.valueOf(c));
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
-							.getValue(c, r));
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testLongTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final LongTable table = new DefaultLongTable(2, 2);
-		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
-		table.get(1).fill(new long[] { -9223372036854775808l, 4 });
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 11l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 11l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(cols[c].name, String.valueOf(c));
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
-							.getValue(c, r));
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testFloatTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final FloatTable table = new DefaultFloatTable(4, 2);
-		table.get(0).fill(new float[] { -380129.125f, 0.25f });
-		table.get(1).fill(new float[] { 9871234.0f, -12.5f });
-		table.get(2).fill(new float[] { 0.0625f, 13208.03125f });
-		table.get(3).fill(new float[] { -0.0625f, 1908471790.5f });
-
-		final String[] headers = new String[] { "H1", "H2", "H3", "H4" };
-
-		for (int i = 0; i < table.getColumnCount(); i++) {
-			table.get(i).setHeader(headers[i]);
-		}
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 21l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 21l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.DoubleColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(cols[c].name, table.get(c).getHeader());
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.DoubleColumn) cols[c]).values[r], table
-							.getValue(c, r), 0);
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testDoubleArrayTable(
-		@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final GenericTable table = new DefaultGenericTable();
-		final DefaultColumn<DoubleArray> ij0 = new DefaultColumn<>(
-			DoubleArray.class, "H1");
-		final DefaultColumn<DoubleArray> ij1 = new DefaultColumn<>(
-			DoubleArray.class, "H2");
-		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
-		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
-		table.add(ij0);
-		table.add(ij1);
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 4l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 4l);
-				assertEquals(cols.length, table.getColumnCount());
-				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[0]));
-				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[1]));
-
-				final omero.grid.DoubleArrayColumn c0 =
-					(omero.grid.DoubleArrayColumn) cols[0];
-				final omero.grid.DoubleArrayColumn c1 =
-					(omero.grid.DoubleArrayColumn) cols[1];
-				assertEquals(c0.values.length, table.getRowCount());
-				assertEquals(c1.values.length, table.getRowCount());
-				assertEquals(c0.name, table.get(0).getHeader());
-				assertEquals(c1.name, table.get(1).getHeader());
-				assertEquals(c0.size, 3);
-				assertEquals(c1.size, 3);
-
-				assertArrayEquals(c0.values[0], ij0.get(0).getArray(), 0);
-				assertArrayEquals(c1.values[0], ij1.get(0).getArray(), 0);
-			}
-		};
-	}
-
-	@Test
-	public void testBoolArrayTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final GenericTable table = new DefaultGenericTable();
-		final DefaultColumn<BoolArray> ij0 = new DefaultColumn<>(
-			BoolArray.class);
-		final DefaultColumn<BoolArray> ij1 = new DefaultColumn<>(
-			BoolArray.class);
-
-		ij0.add(new BoolArray(new boolean[] { true, false }));
-		ij0.add(new BoolArray(new boolean[] { false, false }));
-		ij1.add(new BoolArray(new boolean[] { true, true }));
-		ij1.add(new BoolArray(new boolean[] { false, true }));
-
-		table.add(ij0);
-		table.add(ij1);
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 22l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 22l);
-				assertEquals(cols.length, table.getColumnCount());
-				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[0]));
-				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[1]));
-
-				final omero.grid.LongArrayColumn c0 =
-					(omero.grid.LongArrayColumn) cols[0];
-				final omero.grid.LongArrayColumn c1 =
-					(omero.grid.LongArrayColumn) cols[1];
-				assertEquals(c0.name, "0");
-				assertEquals(c1.name, "1");
-				assertEquals(c0.values.length, table.getRowCount());
-				assertEquals(c1.values.length, table.getRowCount());
-				assertEquals(c0.size, 2);
-				assertEquals(c1.size, 2);
-
-				for (int r = 0; r < c0.values.length; r++) {
-					for (int z = 0; z < c0.values[r].length; z++) {
-						final int i = ij0.get(r).get(z) ? 1 : 0;
-						assertEquals(c0.values[r][z], i);
-					}
-				}
-
-				for (int r = 0; r < c1.values.length; r++) {
-					for (int z = 0; z < c1.values[r].length; z++) {
-						final int i = ij1.get(r).get(z) ? 1 : 0;
-						assertEquals(c1.values[r][z], i);
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testCharTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final CharTable table = new DefaultCharTable(5, 2);
-		table.get(0).fill(new char[] { 'q', 'V' });
-		table.get(1).fill(new char[] { '2', '$' });
-		table.get(2).fill(new char[] { 'b', 'a' });
-		table.get(3).fill(new char[] { '\t', '\n' });
-		table.get(4).fill(new char[] { '.', ' ' });
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 103l);
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 103l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.StringColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.StringColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(((omero.grid.StringColumn) cols[c]).size, 1);
-					assertEquals(cols[c].name, String.valueOf(c));
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.StringColumn) cols[c]).values[r], String
-							.valueOf(table.getValue(c, r)));
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testReferenceTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final GenericTable table = new DefaultGenericTable();
-		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
-		final OMERORefColumn rc1 = new OMERORefColumn(OMERORef.WELL);
-		final OMERORefColumn rc2 = new OMERORefColumn(OMERORef.WELL);
-		rc0.fill(new long[] { 2314, 3141324, 1235 });
-		rc1.fill(new long[] { 1234, 18367, 82156 });
-		rc2.fill(new long[] { 3198, 968431, 5489 });
-		table.add(rc0);
-		table.add(rc1);
-		table.add(rc2);
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 9l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 9l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				for (int c = 0; c < table.getColumnCount(); c++) {
-					assertTrue(omero.grid.WellColumn.class.isInstance(cols[c]));
-					assertEquals(((omero.grid.WellColumn) cols[c]).values.length, table
-						.getRowCount());
-					assertEquals(cols[c].name, String.valueOf(c));
-					for (int r = 0; r < table.getRowCount(); r++) {
-						assertEquals(((omero.grid.WellColumn) cols[c]).values[r],
-							((OMERORefColumn) table.get(c)).getValue(r));
-					}
-				}
-			}
-		};
-	}
-
-	@Test
-	public void testMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-		@Mocked final OriginalFile fileMock) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-		DSOutOfServiceException, DSAccessException
-	{
-		final GenericTable table = new DefaultGenericTable();
-		final BoolColumn ijc0 = new BoolColumn("h0");
-		final DoubleColumn ijc1 = new DoubleColumn("h1");
-		final DefaultColumn<String> ijc2 = new DefaultColumn<>(String.class,
-			"h2");
-		final DefaultColumn<IntArray> ijc3 = new DefaultColumn<>(
-			IntArray.class, "h3");
-		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
-		ijc0.fill(new boolean[] { true, false });
-		ijc1.fill(new double[] { 0.03125, -2134.5 });
-		ijc2.add("abc");
-		ijc2.add("123");
-		ijc3.add(new IntArray(new int[] { 9012, 1294 }));
-		ijc3.add(new IntArray(new int[] { -4123, -9 }));
-		ijc4.fill(new long[] { 2314, 1234 });
-		table.add(ijc0);
-		table.add(ijc1);
-		table.add(ijc2);
-		table.add(ijc3);
-		table.add(ijc4);
-
-		// Create expectations
-		// NB: Cannot pass parameters to @Before methods
-		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-			fileMock, 12l);
-
-		final long id = service.uploadTable(credentials, "table", table, 0);
-
-		// Confirm method calls made in this order
-		new VerificationsInOrder() {
-
-			{
-				final omero.grid.Column[] cols;
-				sessionMock.getGateway();
-				sessionMock.getSecurityContext();
-				gatewayMock.getSharedResources(scMock);
-				srMock.newTable(anyInt, anyString);
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-				tableMock.getOriginalFile();
-				fileMock.getId();
-				tableMock.close();
-
-				// Tests
-				// NB: Tests must occur in verification
-				assertEquals(id, 12l);
-				assertEquals(cols.length, table.getColumnCount());
-
-				assertTrue(omero.grid.BoolColumn.class.isInstance(cols[0]));
-				assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[1]));
-				assertTrue(omero.grid.StringColumn.class.isInstance(cols[2]));
-				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[3]));
-				assertTrue(omero.grid.RoiColumn.class.isInstance(cols[4]));
-
-				final omero.grid.BoolColumn oc0 = (omero.grid.BoolColumn) cols[0];
-				final omero.grid.DoubleColumn oc1 = (omero.grid.DoubleColumn) cols[1];
-				final omero.grid.StringColumn oc2 = (omero.grid.StringColumn) cols[2];
-				final omero.grid.LongArrayColumn oc3 =
-					(omero.grid.LongArrayColumn) cols[3];
-				final omero.grid.RoiColumn oc4 = (omero.grid.RoiColumn) cols[4];
-
-				assertEquals(oc0.name, "h0");
-				assertEquals(oc1.name, "h1");
-				assertEquals(oc2.name, "h2");
-				assertEquals(oc3.name, "h3");
-				assertEquals(oc4.name, "h4");
-
-				assertEquals(oc0.values.length, ijc0.size());
-				assertEquals(oc1.values.length, ijc1.size());
-				assertEquals(oc2.values.length, ijc2.size());
-				assertEquals(oc3.values.length, ijc3.size());
-				assertEquals(oc4.values.length, ijc4.size());
-
-				assertEquals(oc2.size, 3);
-				assertEquals(oc3.size, 2);
-
-				for (int i = 0; i < oc0.values.length; i++) {
-					assertEquals(oc0.values[i], ijc0.getValue(i));
-				}
-				for (int i = 0; i < oc1.values.length; i++) {
-					assertEquals(oc1.values[i], ijc1.getValue(i), 0);
-				}
-				for (int i = 0; i < oc2.values.length; i++) {
-					assertEquals(oc2.values[i], ijc2.getValue(i));
-				}
-				for (int i = 0; i < oc3.values.length; i++) {
-					assertEquals(oc3.values[i].length, ijc3.get(i).getArray().length);
-					for (int j = 0; j < oc3.values[0].length; j++) {
-						assertEquals(oc3.values[i][j], ijc3.get(i).getArray()[j]);
-					}
-				}
-				for (int i = 0; i < oc4.values.length; i++) {
-					assertEquals(oc4.values[i], ijc4.getValue(i));
-				}
-			}
-		};
-	}
-
-	// -- Helper methods --
-
-	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-		final Gateway gatewayMock, final SecurityContext scMock,
-		final omero.grid.SharedResourcesPrx srMock, final TablePrx tableMock,
-		final OriginalFile fileMock, final long tableID) throws ServerError,
-		PermissionDeniedException, CannotCreateSessionException,
-		DSOutOfServiceException
-	{
-		new NonStrictExpectations() {
-
-			{
-				new DefaultOMEROSession(withNotNull());
-				sessionMock.getGateway();
-				result = gatewayMock;
-				sessionMock.getSecurityContext();
-				result = scMock;
-				gatewayMock.getSharedResources(scMock);
-				result = srMock;
-				srMock.newTable(1, "table");
-				result = tableMock;
-
-				tableMock.initialize((omero.grid.Column[]) any);
-				tableMock.addData((omero.grid.Column[]) any);
-				tableMock.getOriginalFile();
-				result = fileMock;
-				fileMock.getId();
-				result = omero.rtypes.rlong(tableID);
-
-				tableMock.close();
-			}
-		};
-	}
+//	@Test
+//	public void testBoolTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final BoolTable table = new DefaultBoolTable(2, 4);
+//		table.get(0).fill(new boolean[] { true, true, false, false });
+//		table.get(1).fill(new boolean[] { true, false, true, false });
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 3l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 3l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.BoolColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.BoolColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(cols[c].name, String.valueOf(c));
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.BoolColumn) cols[c]).values[r], table
+//							.getValue(c, r));
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testShortTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final ShortTable table = new DefaultShortTable(6, 3);
+//		table.get(0).fill(new short[] { -32768, 0, 32767 });
+//		table.get(1).fill(new short[] { 12, -12, 5 });
+//		table.get(2).fill(new short[] { 10000, 20000, -30000 });
+//		table.get(3).fill(new short[] { 1111, 2222, 8888 });
+//		table.get(4).fill(new short[] { -4, -17, -31194 });
+//		table.get(5).fill(new short[] { 0, 17239, -20 });
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 22l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 22l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(cols[c].name, String.valueOf(c));
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
+//							.getValue(c, r));
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testLongTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final LongTable table = new DefaultLongTable(2, 2);
+//		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
+//		table.get(1).fill(new long[] { -9223372036854775808l, 4 });
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 11l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 11l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(cols[c].name, String.valueOf(c));
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
+//							.getValue(c, r));
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testFloatTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final FloatTable table = new DefaultFloatTable(4, 2);
+//		table.get(0).fill(new float[] { -380129.125f, 0.25f });
+//		table.get(1).fill(new float[] { 9871234.0f, -12.5f });
+//		table.get(2).fill(new float[] { 0.0625f, 13208.03125f });
+//		table.get(3).fill(new float[] { -0.0625f, 1908471790.5f });
+//
+//		final String[] headers = new String[] { "H1", "H2", "H3", "H4" };
+//
+//		for (int i = 0; i < table.getColumnCount(); i++) {
+//			table.get(i).setHeader(headers[i]);
+//		}
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 21l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 21l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.DoubleColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(cols[c].name, table.get(c).getHeader());
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.DoubleColumn) cols[c]).values[r], table
+//							.getValue(c, r), 0);
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testDoubleArrayTable(
+//		@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final GenericTable table = new DefaultGenericTable();
+//		final DefaultColumn<DoubleArray> ij0 = new DefaultColumn<>(
+//			DoubleArray.class, "H1");
+//		final DefaultColumn<DoubleArray> ij1 = new DefaultColumn<>(
+//			DoubleArray.class, "H2");
+//		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
+//		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
+//		table.add(ij0);
+//		table.add(ij1);
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 4l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 4l);
+//				assertEquals(cols.length, table.getColumnCount());
+//				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[0]));
+//				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[1]));
+//
+//				final omero.grid.DoubleArrayColumn c0 =
+//					(omero.grid.DoubleArrayColumn) cols[0];
+//				final omero.grid.DoubleArrayColumn c1 =
+//					(omero.grid.DoubleArrayColumn) cols[1];
+//				assertEquals(c0.values.length, table.getRowCount());
+//				assertEquals(c1.values.length, table.getRowCount());
+//				assertEquals(c0.name, table.get(0).getHeader());
+//				assertEquals(c1.name, table.get(1).getHeader());
+//				assertEquals(c0.size, 3);
+//				assertEquals(c1.size, 3);
+//
+//				assertArrayEquals(c0.values[0], ij0.get(0).getArray(), 0);
+//				assertArrayEquals(c1.values[0], ij1.get(0).getArray(), 0);
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testBoolArrayTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final GenericTable table = new DefaultGenericTable();
+//		final DefaultColumn<BoolArray> ij0 = new DefaultColumn<>(
+//			BoolArray.class);
+//		final DefaultColumn<BoolArray> ij1 = new DefaultColumn<>(
+//			BoolArray.class);
+//
+//		ij0.add(new BoolArray(new boolean[] { true, false }));
+//		ij0.add(new BoolArray(new boolean[] { false, false }));
+//		ij1.add(new BoolArray(new boolean[] { true, true }));
+//		ij1.add(new BoolArray(new boolean[] { false, true }));
+//
+//		table.add(ij0);
+//		table.add(ij1);
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 22l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 22l);
+//				assertEquals(cols.length, table.getColumnCount());
+//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[0]));
+//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[1]));
+//
+//				final omero.grid.LongArrayColumn c0 =
+//					(omero.grid.LongArrayColumn) cols[0];
+//				final omero.grid.LongArrayColumn c1 =
+//					(omero.grid.LongArrayColumn) cols[1];
+//				assertEquals(c0.name, "0");
+//				assertEquals(c1.name, "1");
+//				assertEquals(c0.values.length, table.getRowCount());
+//				assertEquals(c1.values.length, table.getRowCount());
+//				assertEquals(c0.size, 2);
+//				assertEquals(c1.size, 2);
+//
+//				for (int r = 0; r < c0.values.length; r++) {
+//					for (int z = 0; z < c0.values[r].length; z++) {
+//						final int i = ij0.get(r).get(z) ? 1 : 0;
+//						assertEquals(c0.values[r][z], i);
+//					}
+//				}
+//
+//				for (int r = 0; r < c1.values.length; r++) {
+//					for (int z = 0; z < c1.values[r].length; z++) {
+//						final int i = ij1.get(r).get(z) ? 1 : 0;
+//						assertEquals(c1.values[r][z], i);
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testCharTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final CharTable table = new DefaultCharTable(5, 2);
+//		table.get(0).fill(new char[] { 'q', 'V' });
+//		table.get(1).fill(new char[] { '2', '$' });
+//		table.get(2).fill(new char[] { 'b', 'a' });
+//		table.get(3).fill(new char[] { '\t', '\n' });
+//		table.get(4).fill(new char[] { '.', ' ' });
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 103l);
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 103l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.StringColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.StringColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(((omero.grid.StringColumn) cols[c]).size, 1);
+//					assertEquals(cols[c].name, String.valueOf(c));
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.StringColumn) cols[c]).values[r], String
+//							.valueOf(table.getValue(c, r)));
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testReferenceTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final GenericTable table = new DefaultGenericTable();
+//		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
+//		final OMERORefColumn rc1 = new OMERORefColumn(OMERORef.WELL);
+//		final OMERORefColumn rc2 = new OMERORefColumn(OMERORef.WELL);
+//		rc0.fill(new long[] { 2314, 3141324, 1235 });
+//		rc1.fill(new long[] { 1234, 18367, 82156 });
+//		rc2.fill(new long[] { 3198, 968431, 5489 });
+//		table.add(rc0);
+//		table.add(rc1);
+//		table.add(rc2);
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 9l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 9l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				for (int c = 0; c < table.getColumnCount(); c++) {
+//					assertTrue(omero.grid.WellColumn.class.isInstance(cols[c]));
+//					assertEquals(((omero.grid.WellColumn) cols[c]).values.length, table
+//						.getRowCount());
+//					assertEquals(cols[c].name, String.valueOf(c));
+//					for (int r = 0; r < table.getRowCount(); r++) {
+//						assertEquals(((omero.grid.WellColumn) cols[c]).values[r],
+//							((OMERORefColumn) table.get(c)).getValue(r));
+//					}
+//				}
+//			}
+//		};
+//	}
+//
+//	@Test
+//	public void testMixedTable(@Mocked final DefaultOMEROSession sessionMock,
+//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
+//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+//		@Mocked final OriginalFile fileMock) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+//		DSOutOfServiceException, DSAccessException
+//	{
+//		final GenericTable table = new DefaultGenericTable();
+//		final BoolColumn ijc0 = new BoolColumn("h0");
+//		final DoubleColumn ijc1 = new DoubleColumn("h1");
+//		final DefaultColumn<String> ijc2 = new DefaultColumn<>(String.class,
+//			"h2");
+//		final DefaultColumn<IntArray> ijc3 = new DefaultColumn<>(
+//			IntArray.class, "h3");
+//		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
+//		ijc0.fill(new boolean[] { true, false });
+//		ijc1.fill(new double[] { 0.03125, -2134.5 });
+//		ijc2.add("abc");
+//		ijc2.add("123");
+//		ijc3.add(new IntArray(new int[] { 9012, 1294 }));
+//		ijc3.add(new IntArray(new int[] { -4123, -9 }));
+//		ijc4.fill(new long[] { 2314, 1234 });
+//		table.add(ijc0);
+//		table.add(ijc1);
+//		table.add(ijc2);
+//		table.add(ijc3);
+//		table.add(ijc4);
+//
+//		// Create expectations
+//		// NB: Cannot pass parameters to @Before methods
+//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
+//			fileMock, 12l);
+//
+//		final long id = service.uploadTable(credentials, "table", table, 0);
+//
+//		// Confirm method calls made in this order
+//		new VerificationsInOrder() {
+//
+//			{
+//				final omero.grid.Column[] cols;
+//				sessionMock.getGateway();
+//				sessionMock.getSecurityContext();
+//				gatewayMock.getSharedResources(scMock);
+//				srMock.newTable(anyInt, anyString);
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+//				tableMock.getOriginalFile();
+//				fileMock.getId();
+//				tableMock.close();
+//
+//				// Tests
+//				// NB: Tests must occur in verification
+//				assertEquals(id, 12l);
+//				assertEquals(cols.length, table.getColumnCount());
+//
+//				assertTrue(omero.grid.BoolColumn.class.isInstance(cols[0]));
+//				assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[1]));
+//				assertTrue(omero.grid.StringColumn.class.isInstance(cols[2]));
+//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[3]));
+//				assertTrue(omero.grid.RoiColumn.class.isInstance(cols[4]));
+//
+//				final omero.grid.BoolColumn oc0 = (omero.grid.BoolColumn) cols[0];
+//				final omero.grid.DoubleColumn oc1 = (omero.grid.DoubleColumn) cols[1];
+//				final omero.grid.StringColumn oc2 = (omero.grid.StringColumn) cols[2];
+//				final omero.grid.LongArrayColumn oc3 =
+//					(omero.grid.LongArrayColumn) cols[3];
+//				final omero.grid.RoiColumn oc4 = (omero.grid.RoiColumn) cols[4];
+//
+//				assertEquals(oc0.name, "h0");
+//				assertEquals(oc1.name, "h1");
+//				assertEquals(oc2.name, "h2");
+//				assertEquals(oc3.name, "h3");
+//				assertEquals(oc4.name, "h4");
+//
+//				assertEquals(oc0.values.length, ijc0.size());
+//				assertEquals(oc1.values.length, ijc1.size());
+//				assertEquals(oc2.values.length, ijc2.size());
+//				assertEquals(oc3.values.length, ijc3.size());
+//				assertEquals(oc4.values.length, ijc4.size());
+//
+//				assertEquals(oc2.size, 3);
+//				assertEquals(oc3.size, 2);
+//
+//				for (int i = 0; i < oc0.values.length; i++) {
+//					assertEquals(oc0.values[i], ijc0.getValue(i));
+//				}
+//				for (int i = 0; i < oc1.values.length; i++) {
+//					assertEquals(oc1.values[i], ijc1.getValue(i), 0);
+//				}
+//				for (int i = 0; i < oc2.values.length; i++) {
+//					assertEquals(oc2.values[i], ijc2.getValue(i));
+//				}
+//				for (int i = 0; i < oc3.values.length; i++) {
+//					assertEquals(oc3.values[i].length, ijc3.get(i).getArray().length);
+//					for (int j = 0; j < oc3.values[0].length; j++) {
+//						assertEquals(oc3.values[i][j], ijc3.get(i).getArray()[j]);
+//					}
+//				}
+//				for (int i = 0; i < oc4.values.length; i++) {
+//					assertEquals(oc4.values[i], ijc4.getValue(i));
+//				}
+//			}
+//		};
+//	}
+//
+//	// -- Helper methods --
+//
+//	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
+//		final Gateway gatewayMock, final SecurityContext scMock,
+//		final omero.grid.SharedResourcesPrx srMock, final TablePrx tableMock,
+//		final OriginalFile fileMock, final long tableID) throws ServerError,
+//		PermissionDeniedException, CannotCreateSessionException,
+//		DSOutOfServiceException
+//	{
+//		new NonStrictExpectations() {
+//
+//			{
+//				new DefaultOMEROSession(withNotNull());
+//				sessionMock.getGateway();
+//				result = gatewayMock;
+//				sessionMock.getSecurityContext();
+//				result = scMock;
+//				gatewayMock.getSharedResources(scMock);
+//				result = srMock;
+//				srMock.newTable(1, "table");
+//				result = tableMock;
+//
+//				tableMock.initialize((omero.grid.Column[]) any);
+//				tableMock.addData((omero.grid.Column[]) any);
+//				tableMock.getOriginalFile();
+//				result = fileMock;
+//				fileMock.getId();
+//				result = omero.rtypes.rlong(tableID);
+//
+//				tableMock.close();
+//			}
+//		};
+//	}
 
 }

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -1,0 +1,724 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2015 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+
+import java.util.concurrent.ExecutionException;
+
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import mockit.VerificationsInOrder;
+import net.imagej.table.BoolColumn;
+import net.imagej.table.BoolTable;
+import net.imagej.table.CharTable;
+import net.imagej.table.DefaultBoolTable;
+import net.imagej.table.DefaultCharTable;
+import net.imagej.table.DefaultColumn;
+import net.imagej.table.DefaultFloatTable;
+import net.imagej.table.DefaultGenericTable;
+import net.imagej.table.DefaultLongTable;
+import net.imagej.table.DefaultShortTable;
+import net.imagej.table.DoubleColumn;
+import net.imagej.table.FloatTable;
+import net.imagej.table.GenericTable;
+import net.imagej.table.LongTable;
+import net.imagej.table.ShortTable;
+import omero.ServerError;
+import omero.api.ServiceFactoryPrx;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.grid.SharedResourcesPrx;
+import omero.grid.TablePrx;
+import omero.model.OriginalFile;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.util.BoolArray;
+import org.scijava.util.DoubleArray;
+import org.scijava.util.IntArray;
+
+/**
+ * Tests {@link DefaultOMEROService#uploadTable}.
+ *
+ * @author Alison Walter
+ */
+public class UploadTableTest {
+
+	private OMEROService service;
+	private OMEROCredentials credentials;
+
+	@Before
+	public void setUp() throws Exception {
+		service = new Context(OMEROService.class).service(OMEROService.class);
+	}
+
+	@After
+	public void tearDown() {
+		if (service != null) {
+			service.getContext().dispose();
+			service = null;
+		}
+	}
+
+	@Test
+	public void testBoolTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final BoolTable table = new DefaultBoolTable(2, 4);
+		table.get(0).fill(new boolean[] { true, true, false, false });
+		table.get(1).fill(new boolean[] { true, false, true, false });
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 3l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 3l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.BoolColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.BoolColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(cols[c].name, String.valueOf(c));
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.BoolColumn) cols[c]).values[r], table
+							.getValue(c, r));
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testShortTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final ShortTable table = new DefaultShortTable(6, 3);
+		table.get(0).fill(new short[] { -32768, 0, 32767 });
+		table.get(1).fill(new short[] { 12, -12, 5 });
+		table.get(2).fill(new short[] { 10000, 20000, -30000 });
+		table.get(3).fill(new short[] { 1111, 2222, 8888 });
+		table.get(4).fill(new short[] { -4, -17, -31194 });
+		table.get(5).fill(new short[] { 0, 17239, -20 });
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 22l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 22l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(cols[c].name, String.valueOf(c));
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
+							.getValue(c, r));
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testLongTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final LongTable table = new DefaultLongTable(2, 2);
+		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
+		table.get(1).fill(new long[] { -9223372036854775808l, 4 });
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 11l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 11l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(cols[c].name, String.valueOf(c));
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
+							.getValue(c, r));
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testFloatTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final FloatTable table = new DefaultFloatTable(4, 2);
+		table.get(0).fill(new float[] { -380129.125f, 0.25f });
+		table.get(1).fill(new float[] { 9871234.0f, -12.5f });
+		table.get(2).fill(new float[] { 0.0625f, 13208.03125f });
+		table.get(3).fill(new float[] { -0.0625f, 1908471790.5f });
+
+		final String[] headers = new String[] { "H1", "H2", "H3", "H4" };
+
+		for (int i = 0; i < table.getColumnCount(); i++) {
+			table.get(i).setHeader(headers[i]);
+		}
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 21l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 21l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.DoubleColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(cols[c].name, table.get(c).getHeader());
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.DoubleColumn) cols[c]).values[r], table
+							.getValue(c, r), 0);
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testDoubleArrayTable(
+		@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final DefaultColumn<DoubleArray> ij0 =
+			new DefaultColumn<DoubleArray>(DoubleArray.class, "H1");
+		final DefaultColumn<DoubleArray> ij1 =
+			new DefaultColumn<DoubleArray>(DoubleArray.class, "H2");
+		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
+		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
+		table.add(ij0);
+		table.add(ij1);
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 4l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 4l);
+				assertEquals(cols.length, table.getColumnCount());
+				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[0]));
+				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[1]));
+
+				final omero.grid.DoubleArrayColumn c0 =
+					(omero.grid.DoubleArrayColumn) cols[0];
+				final omero.grid.DoubleArrayColumn c1 =
+					(omero.grid.DoubleArrayColumn) cols[1];
+				assertEquals(c0.values.length, table.getRowCount());
+				assertEquals(c1.values.length, table.getRowCount());
+				assertEquals(c0.name, table.get(0).getHeader());
+				assertEquals(c1.name, table.get(1).getHeader());
+				assertEquals(c0.size, 3);
+				assertEquals(c1.size, 3);
+
+				assertArrayEquals(c0.values[0], ij0.get(0).getArray(), 0);
+				assertArrayEquals(c1.values[0], ij1.get(0).getArray(), 0);
+			}
+		};
+	}
+
+	@Test
+	public void testBoolArrayTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final DefaultColumn<BoolArray> ij0 =
+			new DefaultColumn<BoolArray>(BoolArray.class);
+		final DefaultColumn<BoolArray> ij1 =
+			new DefaultColumn<BoolArray>(BoolArray.class);
+
+		ij0.add(new BoolArray(new boolean[] { true, false }));
+		ij0.add(new BoolArray(new boolean[] { false, false }));
+		ij1.add(new BoolArray(new boolean[] { true, true }));
+		ij1.add(new BoolArray(new boolean[] { false, true }));
+
+		table.add(ij0);
+		table.add(ij1);
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 22l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 22l);
+				assertEquals(cols.length, table.getColumnCount());
+				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[0]));
+				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[1]));
+
+				final omero.grid.LongArrayColumn c0 =
+					(omero.grid.LongArrayColumn) cols[0];
+				final omero.grid.LongArrayColumn c1 =
+					(omero.grid.LongArrayColumn) cols[1];
+				assertEquals(c0.name, "0");
+				assertEquals(c1.name, "1");
+				assertEquals(c0.values.length, table.getRowCount());
+				assertEquals(c1.values.length, table.getRowCount());
+				assertEquals(c0.size, 2);
+				assertEquals(c1.size, 2);
+
+				for (int r = 0; r < c0.values.length; r++) {
+					for (int z = 0; z < c0.values[r].length; z++) {
+						final int i = ij0.get(r).get(z) ? 1 : 0;
+						assertEquals(c0.values[r][z], i);
+					}
+				}
+
+				for (int r = 0; r < c1.values.length; r++) {
+					for (int z = 0; z < c1.values[r].length; z++) {
+						final int i = ij1.get(r).get(z) ? 1 : 0;
+						assertEquals(c1.values[r][z], i);
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testCharTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final CharTable table = new DefaultCharTable(5, 2);
+		table.get(0).fill(new char[] { 'q', 'V' });
+		table.get(1).fill(new char[] { '2', '$' });
+		table.get(2).fill(new char[] { 'b', 'a' });
+		table.get(3).fill(new char[] { '\t', '\n' });
+		table.get(4).fill(new char[] { '.', ' ' });
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 103l);
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 103l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.StringColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.StringColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(((omero.grid.StringColumn) cols[c]).size, 1);
+					assertEquals(cols[c].name, String.valueOf(c));
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.StringColumn) cols[c]).values[r], String
+							.valueOf(table.getValue(c, r)));
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testReferenceTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
+		final OMERORefColumn rc1 = new OMERORefColumn(OMERORef.WELL);
+		final OMERORefColumn rc2 = new OMERORefColumn(OMERORef.WELL);
+		rc0.fill(new long[] { 2314, 3141324, 1235 });
+		rc1.fill(new long[] { 1234, 18367, 82156 });
+		rc2.fill(new long[] { 3198, 968431, 5489 });
+		table.add(rc0);
+		table.add(rc1);
+		table.add(rc2);
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 9l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 9l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				for (int c = 0; c < table.getColumnCount(); c++) {
+					assertTrue(omero.grid.WellColumn.class.isInstance(cols[c]));
+					assertEquals(((omero.grid.WellColumn) cols[c]).values.length, table
+						.getRowCount());
+					assertEquals(cols[c].name, String.valueOf(c));
+					for (int r = 0; r < table.getRowCount(); r++) {
+						assertEquals(((omero.grid.WellColumn) cols[c]).values[r],
+							((OMERORefColumn) table.get(c)).getValue(r));
+					}
+				}
+			}
+		};
+	}
+
+	@Test
+	public void testMixedTable(@Mocked final DefaultOMEROSession sessionMock,
+		@Mocked final omero.client clientMock,
+		@Mocked final ServiceFactoryPrx sfMock,
+		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
+		@Mocked final OriginalFile fileMock) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException,
+		ExecutionException, DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final BoolColumn ijc0 = new BoolColumn("h0");
+		final DoubleColumn ijc1 = new DoubleColumn("h1");
+		final DefaultColumn<String> ijc2 =
+			new DefaultColumn<String>(String.class, "h2");
+		final DefaultColumn<IntArray> ijc3 =
+			new DefaultColumn<IntArray>(IntArray.class, "h3");
+		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
+		ijc0.fill(new boolean[] { true, false });
+		ijc1.fill(new double[] { 0.03125, -2134.5 });
+		ijc2.add("abc");
+		ijc2.add("123");
+		ijc3.add(new IntArray(new int[] { 9012, 1294 }));
+		ijc3.add(new IntArray(new int[] { -4123, -9 }));
+		ijc4.fill(new long[] { 2314, 1234 });
+		table.add(ijc0);
+		table.add(ijc1);
+		table.add(ijc2);
+		table.add(ijc3);
+		table.add(ijc4);
+
+		// Create expectations
+		// NB: Cannot pass parameters to @Before methods
+		setUpMethodCalls(sessionMock, clientMock, sfMock, srMock, tableMock,
+			fileMock, 12l);
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+
+		// Confirm method calls made in this order
+		new VerificationsInOrder() {
+			{
+				final omero.grid.Column[] cols;
+				sessionMock.getClient();
+				clientMock.getSession();
+				sfMock.sharedResources();
+				srMock.newTable(anyInt, anyString);
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData(cols = withCapture()); // Capture OMERO columns
+				tableMock.getOriginalFile();
+				fileMock.getId();
+				tableMock.close();
+				sessionMock.close();
+
+				// Tests
+				// NB: Tests must occur in verification
+				assertEquals(id, 12l);
+				assertEquals(cols.length, table.getColumnCount());
+
+				assertTrue(omero.grid.BoolColumn.class.isInstance(cols[0]));
+				assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[1]));
+				assertTrue(omero.grid.StringColumn.class.isInstance(cols[2]));
+				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[3]));
+				assertTrue(omero.grid.RoiColumn.class.isInstance(cols[4]));
+
+				final omero.grid.BoolColumn oc0 = (omero.grid.BoolColumn) cols[0];
+				final omero.grid.DoubleColumn oc1 = (omero.grid.DoubleColumn) cols[1];
+				final omero.grid.StringColumn oc2 = (omero.grid.StringColumn) cols[2];
+				final omero.grid.LongArrayColumn oc3 =
+					(omero.grid.LongArrayColumn) cols[3];
+				final omero.grid.RoiColumn oc4 = (omero.grid.RoiColumn) cols[4];
+
+				assertEquals(oc0.name, "h0");
+				assertEquals(oc1.name, "h1");
+				assertEquals(oc2.name, "h2");
+				assertEquals(oc3.name, "h3");
+				assertEquals(oc4.name, "h4");
+
+				assertEquals(oc0.values.length, ijc0.size());
+				assertEquals(oc1.values.length, ijc1.size());
+				assertEquals(oc2.values.length, ijc2.size());
+				assertEquals(oc3.values.length, ijc3.size());
+				assertEquals(oc4.values.length, ijc4.size());
+
+				assertEquals(oc2.size, 3);
+				assertEquals(oc3.size, 2);
+
+				for (int i = 0; i < oc0.values.length; i++) {
+					assertEquals(oc0.values[i], ijc0.getValue(i));
+				}
+				for (int i = 0; i < oc1.values.length; i++) {
+					assertEquals(oc1.values[i], ijc1.getValue(i), 0);
+				}
+				for (int i = 0; i < oc2.values.length; i++) {
+					assertEquals(oc2.values[i], ijc2.getValue(i));
+				}
+				for (int i = 0; i < oc3.values.length; i++) {
+					assertEquals(oc3.values[i].length, ijc3.get(i).getArray().length);
+					for (int j = 0; j < oc3.values[0].length; j++) {
+						assertEquals(oc3.values[i][j], ijc3.get(i).getArray()[j]);
+					}
+				}
+				for (int i = 0; i < oc4.values.length; i++) {
+					assertEquals(oc4.values[i], ijc4.getValue(i));
+				}
+			}
+		};
+	}
+
+	// -- Helper methods --
+
+	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
+		final omero.client clientMock, final omero.api.ServiceFactoryPrx sfMock,
+		final omero.grid.SharedResourcesPrx srMock, final TablePrx tableMock,
+		final OriginalFile fileMock, final long tableID) throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException
+	{
+		new NonStrictExpectations() {
+			{
+				new DefaultOMEROSession(withNotNull());
+				sessionMock.getClient();
+				result = clientMock;
+				clientMock.getSession();
+				result = sfMock;
+				sfMock.sharedResources();
+				result = srMock;
+				srMock.newTable(1, "table");
+				result = tableMock;
+
+				tableMock.initialize((omero.grid.Column[]) any);
+				tableMock.addData((omero.grid.Column[]) any);
+				tableMock.getOriginalFile();
+				result = fileMock;
+				fileMock.getId();
+				result = omero.rtypes.rlong(tableID);
+
+				tableMock.close();
+			}
+		};
+	}
+
+}

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -25,49 +25,9 @@
 
 package net.imagej.omero;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.concurrent.ExecutionException;
-
-import net.imagej.table.BoolColumn;
-import net.imagej.table.BoolTable;
-import net.imagej.table.CharTable;
-import net.imagej.table.DefaultBoolTable;
-import net.imagej.table.DefaultCharTable;
-import net.imagej.table.DefaultColumn;
-import net.imagej.table.DefaultFloatTable;
-import net.imagej.table.DefaultGenericTable;
-import net.imagej.table.DefaultLongTable;
-import net.imagej.table.DefaultShortTable;
-import net.imagej.table.DoubleColumn;
-import net.imagej.table.FloatTable;
-import net.imagej.table.GenericTable;
-import net.imagej.table.LongTable;
-import net.imagej.table.ShortTable;
-
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.scijava.Context;
-import org.scijava.util.BoolArray;
-import org.scijava.util.DoubleArray;
-import org.scijava.util.IntArray;
-
-import Glacier2.CannotCreateSessionException;
-import Glacier2.PermissionDeniedException;
-import mockit.Mocked;
-import mockit.NonStrictExpectations;
-import mockit.VerificationsInOrder;
-import omero.ServerError;
-import omero.gateway.Gateway;
-import omero.gateway.SecurityContext;
-import omero.gateway.exception.DSAccessException;
-import omero.gateway.exception.DSOutOfServiceException;
-import omero.grid.SharedResourcesPrx;
-import omero.grid.TablePrx;
-import omero.model.OriginalFile;
 
 /**
  * Tests {@link DefaultOMEROService#uploadTable}.

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -25,9 +25,56 @@
 
 package net.imagej.omero;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+
+import net.imagej.table.BoolColumn;
+import net.imagej.table.BoolTable;
+import net.imagej.table.CharTable;
+import net.imagej.table.DefaultBoolTable;
+import net.imagej.table.DefaultCharTable;
+import net.imagej.table.DefaultColumn;
+import net.imagej.table.DefaultFloatTable;
+import net.imagej.table.DefaultGenericTable;
+import net.imagej.table.DefaultLongTable;
+import net.imagej.table.DefaultShortTable;
+import net.imagej.table.DoubleColumn;
+import net.imagej.table.FloatTable;
+import net.imagej.table.GenericTable;
+import net.imagej.table.LongTable;
+import net.imagej.table.ShortTable;
+import net.imagej.table.Table;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.scijava.Context;
+import org.scijava.util.ByteArray;
+import org.scijava.util.DoubleArray;
+import org.scijava.util.IntArray;
+import org.scijava.util.PrimitiveArray;
+
+import Glacier2.CannotCreateSessionException;
+import Glacier2.PermissionDeniedException;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import omero.ServerError;
+import omero.gateway.Gateway;
+import omero.gateway.SecurityContext;
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.facility.BrowseFacility;
+import omero.gateway.facility.TablesFacility;
+import omero.gateway.model.DataObject;
+import omero.gateway.model.ImageData;
+import omero.gateway.model.ROIData;
+import omero.gateway.model.TableData;
+import omero.gateway.model.TableDataColumn;
+import omero.gateway.model.WellSampleData;
+import omero.model.RoiI;
+import omero.model.WellSampleI;
 
 /**
  * Tests {@link DefaultOMEROService#uploadTable}.
@@ -36,644 +83,426 @@ import org.scijava.Context;
  */
 public class UploadTableTest {
 
-	private OMEROService service;
 	private OMEROCredentials credentials;
+	private OMEROService service;
+
+	@Mocked
+	private DefaultOMEROSession session;
+
+	@Mocked
+	private Gateway gateway;
+
+	@Mocked
+	private TablesFacility tablesFacility;
+
+	@Mocked
+	private BrowseFacility browseFacility;
 
 	@Before
-	public void setUp() throws Exception {
-		service = new Context(OMEROService.class).service(OMEROService.class);
+	public void setUp() {
+		credentials = new OMEROCredentials();
+		service = new Context(OMEROService.class).getService(OMEROService.class);
 	}
 
 	@After
 	public void tearDown() {
-		if (service != null) {
-			service.getContext().dispose();
-			service = null;
+		service.dispose();
+	}
+
+	@Test
+	public void testBoolTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final BoolTable table = new DefaultBoolTable(2, 4);
+		table.get(0).fill(new boolean[] { true, true, false, false });
+		table.get(1).fill(new boolean[] { true, false, true, false });
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Boolean.class);
+			}
+		};
+	}
+
+	@Test
+	public void testShortTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final ShortTable table = new DefaultShortTable(6, 3);
+		table.get(0).fill(new short[] { -32768, 0, 32767 });
+		table.get(1).fill(new short[] { 12, -12, 5 });
+		table.get(2).fill(new short[] { 10000, 20000, -30000 });
+		table.get(3).fill(new short[] { 1111, 2222, 8888 });
+		table.get(4).fill(new short[] { -4, -17, -31194 });
+		table.get(5).fill(new short[] { 0, 17239, -20 });
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Long.class);
+			}
+		};
+	}
+
+	@Test
+	public void testLongTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final LongTable table = new DefaultLongTable(2, 2);
+		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
+		table.get(1).fill(new long[] { -9223372036854775808l, 4 });
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Long.class);
+			}
+		};
+	}
+
+	@Test
+	public void testFloatTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final FloatTable table = new DefaultFloatTable(4, 2);
+		table.get(0).fill(new float[] { -380129.125f, 0.25f });
+		table.get(1).fill(new float[] { 9871234.0f, -12.5f });
+		table.get(2).fill(new float[] { 0.0625f, 13208.03125f });
+		table.get(3).fill(new float[] { -0.0625f, 1908471790.5f });
+
+		final String[] headers = new String[] { "H1", "H2", "H3", "H4" };
+
+		for (int i = 0; i < table.getColumnCount(); i++) {
+			table.get(i).setHeader(headers[i]);
+		}
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Double.class);
+			}
+		};
+	}
+
+	@Test
+	public void testDoubleArrayTable() throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final DefaultColumn<DoubleArray> ij0 = new DefaultColumn<>(
+			DoubleArray.class, "H1");
+		final DefaultColumn<DoubleArray> ij1 = new DefaultColumn<>(
+			DoubleArray.class, "H2");
+		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
+		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
+		table.add(ij0);
+		table.add(ij1);
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Double[].class);
+			}
+		};
+	}
+
+	@Test
+	public void testByteArrayTable() throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final DefaultColumn<ByteArray> ij0 = new DefaultColumn<>(ByteArray.class);
+		final DefaultColumn<ByteArray> ij1 = new DefaultColumn<>(ByteArray.class);
+
+		ij0.add(new ByteArray(new byte[] { -128, 127 }));
+		ij0.add(new ByteArray(new byte[] { 0, 10 }));
+		ij1.add(new ByteArray(new byte[] { 112, 42 }));
+		ij1.add(new ByteArray(new byte[] { -13, -84 }));
+
+		table.add(ij0);
+		table.add(ij1);
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Long[].class);
+			}
+		};
+	}
+
+	@Test
+	public void testCharTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final CharTable table = new DefaultCharTable(5, 2);
+		table.get(0).fill(new char[] { 'q', 'V' });
+		table.get(1).fill(new char[] { '2', '$' });
+		table.get(2).fill(new char[] { 'b', 'a' });
+		table.get(3).fill(new char[] { '\t', '\n' });
+		table.get(4).fill(new char[] { '.', ' ' });
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, String.class);
+			}
+		};
+	}
+
+	@Test
+	public void testReferenceTable() throws ServerError,
+		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
+		DSOutOfServiceException, DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
+		final OMERORefColumn rc1 = new OMERORefColumn(OMERORef.WELL);
+		final OMERORefColumn rc2 = new OMERORefColumn(OMERORef.WELL);
+		rc0.fill(new long[] { 2314, 3141324, 1235 });
+		rc1.fill(new long[] { 1234, 18367, 82156 });
+		rc2.fill(new long[] { 3198, 968431, 5489 });
+		table.add(rc0);
+		table.add(rc1);
+		table.add(rc2);
+
+		final Object[][] wells = new Object[3][3];
+		for (int c = 0; c < table.getColumnCount(); c++) {
+			for (int r = 0; r < table.getRowCount(); r++) {
+				wells[c][r] = new WellSampleData(new WellSampleI((long) table.get(c, r),
+					false));
+			}
+			((OMERORefColumn) table.get(c)).setOriginalData(wells[c]);
+		}
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, WellSampleData.class);
+			}
+		};
+	}
+
+	@Test
+	public void testMixedTable() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, ExecutionException, DSOutOfServiceException,
+		DSAccessException
+	{
+		final GenericTable table = new DefaultGenericTable();
+		final BoolColumn ijc0 = new BoolColumn("h0");
+		final DoubleColumn ijc1 = new DoubleColumn("h1");
+		final DefaultColumn<String> ijc2 = new DefaultColumn<>(String.class, "h2");
+		final DefaultColumn<IntArray> ijc3 = new DefaultColumn<>(IntArray.class,
+			"h3");
+		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
+		ijc0.fill(new boolean[] { true, false });
+		ijc1.fill(new double[] { 0.03125, -2134.5 });
+		ijc2.add("abc");
+		ijc2.add("123");
+		ijc3.add(new IntArray(new int[] { 9012, 1294 }));
+		ijc3.add(new IntArray(new int[] { -4123, -9 }));
+		ijc4.fill(new long[] { 2314, 1234 });
+		ijc4.setOriginalData(new Object[] { new ROIData(new RoiI(2314, true)),
+			new ROIData(new RoiI(1234, true)) });
+		table.add(ijc0);
+		table.add(ijc1);
+		table.add(ijc2);
+		table.add(ijc3);
+		table.add(ijc4);
+
+		// Create expectations
+		setUpMethodCalls();
+
+		final long id = service.uploadTable(credentials, "table", table, 0);
+		assertEquals(id, -1);
+
+		// NB: Can only capture in a Verifications block
+		new Verifications() {
+
+			{
+				TableData td;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, td = withCapture());
+
+				tableEquals(table, td, Boolean.class, Double.class, String.class,
+					Long[].class, ROIData.class);
+			}
+		};
+	}
+
+	// -- Helper methods --
+
+	private void setUpMethodCalls() throws ServerError, PermissionDeniedException,
+		CannotCreateSessionException, DSOutOfServiceException, ExecutionException,
+		DSAccessException
+	{
+		new Expectations() {
+
+			{
+				new DefaultOMEROSession(credentials);
+
+				gateway.getFacility(BrowseFacility.class);
+				result = browseFacility;
+				browseFacility.getImage((SecurityContext) any, anyLong);
+				result = new ImageData();
+
+				gateway.getFacility(TablesFacility.class);
+				result = tablesFacility;
+				tablesFacility.addTable((SecurityContext) any, (ImageData) any,
+					anyString, (TableData) any);
+				result = new TableData((TableDataColumn[]) any, (Object[][]) any);
+			}
+		};
+	}
+
+	private void tableEquals(final Table<?, ?> imageJTable,
+		final TableData omeroTable, final Class<?>... type)
+	{
+
+		final TableDataColumn[] tdc = omeroTable.getColumns();
+		final Object[][] data = omeroTable.getData();
+		assertEquals(imageJTable.getColumnCount(), tdc.length);
+		assertEquals(imageJTable.getRowCount(), omeroTable.getNumberOfRows());
+
+		for (int r = 0; r < omeroTable.getNumberOfRows(); r++) {
+			for (int c = 0; c < tdc.length; c++) {
+				final Class<?> imageJType = type.length == 1 ? type[0] : type[c];
+				assertColDataEquals(imageJTable.get(c, r), data[c][r]);
+				assertEquals(imageJType, tdc[c].getType());
+				assertHeadersEqual(imageJTable.getColumnHeader(c), tdc[c].getName(), c);
+			}
 		}
 	}
 
-//	@Test
-//	public void testBoolTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final BoolTable table = new DefaultBoolTable(2, 4);
-//		table.get(0).fill(new boolean[] { true, true, false, false });
-//		table.get(1).fill(new boolean[] { true, false, true, false });
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 3l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 3l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.BoolColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.BoolColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(cols[c].name, String.valueOf(c));
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.BoolColumn) cols[c]).values[r], table
-//							.getValue(c, r));
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testShortTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final ShortTable table = new DefaultShortTable(6, 3);
-//		table.get(0).fill(new short[] { -32768, 0, 32767 });
-//		table.get(1).fill(new short[] { 12, -12, 5 });
-//		table.get(2).fill(new short[] { 10000, 20000, -30000 });
-//		table.get(3).fill(new short[] { 1111, 2222, 8888 });
-//		table.get(4).fill(new short[] { -4, -17, -31194 });
-//		table.get(5).fill(new short[] { 0, 17239, -20 });
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 22l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 22l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(cols[c].name, String.valueOf(c));
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
-//							.getValue(c, r));
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testLongTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final LongTable table = new DefaultLongTable(2, 2);
-//		table.get(0).fill(new long[] { 9223372036854775807l, 0 });
-//		table.get(1).fill(new long[] { -9223372036854775808l, 4 });
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 11l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 11l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.LongColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.LongColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(cols[c].name, String.valueOf(c));
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.LongColumn) cols[c]).values[r], table
-//							.getValue(c, r));
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testFloatTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final FloatTable table = new DefaultFloatTable(4, 2);
-//		table.get(0).fill(new float[] { -380129.125f, 0.25f });
-//		table.get(1).fill(new float[] { 9871234.0f, -12.5f });
-//		table.get(2).fill(new float[] { 0.0625f, 13208.03125f });
-//		table.get(3).fill(new float[] { -0.0625f, 1908471790.5f });
-//
-//		final String[] headers = new String[] { "H1", "H2", "H3", "H4" };
-//
-//		for (int i = 0; i < table.getColumnCount(); i++) {
-//			table.get(i).setHeader(headers[i]);
-//		}
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 21l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 21l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.DoubleColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(cols[c].name, table.get(c).getHeader());
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.DoubleColumn) cols[c]).values[r], table
-//							.getValue(c, r), 0);
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testDoubleArrayTable(
-//		@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final GenericTable table = new DefaultGenericTable();
-//		final DefaultColumn<DoubleArray> ij0 = new DefaultColumn<>(
-//			DoubleArray.class, "H1");
-//		final DefaultColumn<DoubleArray> ij1 = new DefaultColumn<>(
-//			DoubleArray.class, "H2");
-//		ij0.add(new DoubleArray(new double[] { 0.5, 0.25, 0.125 }));
-//		ij1.add(new DoubleArray(new double[] { -0.125, -0.0625, 0.03125 }));
-//		table.add(ij0);
-//		table.add(ij1);
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 4l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 4l);
-//				assertEquals(cols.length, table.getColumnCount());
-//				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[0]));
-//				assertTrue(omero.grid.DoubleArrayColumn.class.isInstance(cols[1]));
-//
-//				final omero.grid.DoubleArrayColumn c0 =
-//					(omero.grid.DoubleArrayColumn) cols[0];
-//				final omero.grid.DoubleArrayColumn c1 =
-//					(omero.grid.DoubleArrayColumn) cols[1];
-//				assertEquals(c0.values.length, table.getRowCount());
-//				assertEquals(c1.values.length, table.getRowCount());
-//				assertEquals(c0.name, table.get(0).getHeader());
-//				assertEquals(c1.name, table.get(1).getHeader());
-//				assertEquals(c0.size, 3);
-//				assertEquals(c1.size, 3);
-//
-//				assertArrayEquals(c0.values[0], ij0.get(0).getArray(), 0);
-//				assertArrayEquals(c1.values[0], ij1.get(0).getArray(), 0);
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testBoolArrayTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final GenericTable table = new DefaultGenericTable();
-//		final DefaultColumn<BoolArray> ij0 = new DefaultColumn<>(
-//			BoolArray.class);
-//		final DefaultColumn<BoolArray> ij1 = new DefaultColumn<>(
-//			BoolArray.class);
-//
-//		ij0.add(new BoolArray(new boolean[] { true, false }));
-//		ij0.add(new BoolArray(new boolean[] { false, false }));
-//		ij1.add(new BoolArray(new boolean[] { true, true }));
-//		ij1.add(new BoolArray(new boolean[] { false, true }));
-//
-//		table.add(ij0);
-//		table.add(ij1);
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 22l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 22l);
-//				assertEquals(cols.length, table.getColumnCount());
-//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[0]));
-//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[1]));
-//
-//				final omero.grid.LongArrayColumn c0 =
-//					(omero.grid.LongArrayColumn) cols[0];
-//				final omero.grid.LongArrayColumn c1 =
-//					(omero.grid.LongArrayColumn) cols[1];
-//				assertEquals(c0.name, "0");
-//				assertEquals(c1.name, "1");
-//				assertEquals(c0.values.length, table.getRowCount());
-//				assertEquals(c1.values.length, table.getRowCount());
-//				assertEquals(c0.size, 2);
-//				assertEquals(c1.size, 2);
-//
-//				for (int r = 0; r < c0.values.length; r++) {
-//					for (int z = 0; z < c0.values[r].length; z++) {
-//						final int i = ij0.get(r).get(z) ? 1 : 0;
-//						assertEquals(c0.values[r][z], i);
-//					}
-//				}
-//
-//				for (int r = 0; r < c1.values.length; r++) {
-//					for (int z = 0; z < c1.values[r].length; z++) {
-//						final int i = ij1.get(r).get(z) ? 1 : 0;
-//						assertEquals(c1.values[r][z], i);
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testCharTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final CharTable table = new DefaultCharTable(5, 2);
-//		table.get(0).fill(new char[] { 'q', 'V' });
-//		table.get(1).fill(new char[] { '2', '$' });
-//		table.get(2).fill(new char[] { 'b', 'a' });
-//		table.get(3).fill(new char[] { '\t', '\n' });
-//		table.get(4).fill(new char[] { '.', ' ' });
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 103l);
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 103l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.StringColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.StringColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(((omero.grid.StringColumn) cols[c]).size, 1);
-//					assertEquals(cols[c].name, String.valueOf(c));
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.StringColumn) cols[c]).values[r], String
-//							.valueOf(table.getValue(c, r)));
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testReferenceTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final GenericTable table = new DefaultGenericTable();
-//		final OMERORefColumn rc0 = new OMERORefColumn(OMERORef.WELL);
-//		final OMERORefColumn rc1 = new OMERORefColumn(OMERORef.WELL);
-//		final OMERORefColumn rc2 = new OMERORefColumn(OMERORef.WELL);
-//		rc0.fill(new long[] { 2314, 3141324, 1235 });
-//		rc1.fill(new long[] { 1234, 18367, 82156 });
-//		rc2.fill(new long[] { 3198, 968431, 5489 });
-//		table.add(rc0);
-//		table.add(rc1);
-//		table.add(rc2);
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 9l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 9l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				for (int c = 0; c < table.getColumnCount(); c++) {
-//					assertTrue(omero.grid.WellColumn.class.isInstance(cols[c]));
-//					assertEquals(((omero.grid.WellColumn) cols[c]).values.length, table
-//						.getRowCount());
-//					assertEquals(cols[c].name, String.valueOf(c));
-//					for (int r = 0; r < table.getRowCount(); r++) {
-//						assertEquals(((omero.grid.WellColumn) cols[c]).values[r],
-//							((OMERORefColumn) table.get(c)).getValue(r));
-//					}
-//				}
-//			}
-//		};
-//	}
-//
-//	@Test
-//	public void testMixedTable(@Mocked final DefaultOMEROSession sessionMock,
-//		@Mocked final Gateway gatewayMock, @Mocked final SecurityContext scMock,
-//		@Mocked final SharedResourcesPrx srMock, @Mocked final TablePrx tableMock,
-//		@Mocked final OriginalFile fileMock) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException, ExecutionException,
-//		DSOutOfServiceException, DSAccessException
-//	{
-//		final GenericTable table = new DefaultGenericTable();
-//		final BoolColumn ijc0 = new BoolColumn("h0");
-//		final DoubleColumn ijc1 = new DoubleColumn("h1");
-//		final DefaultColumn<String> ijc2 = new DefaultColumn<>(String.class,
-//			"h2");
-//		final DefaultColumn<IntArray> ijc3 = new DefaultColumn<>(
-//			IntArray.class, "h3");
-//		final OMERORefColumn ijc4 = new OMERORefColumn("h4", OMERORef.ROI);
-//		ijc0.fill(new boolean[] { true, false });
-//		ijc1.fill(new double[] { 0.03125, -2134.5 });
-//		ijc2.add("abc");
-//		ijc2.add("123");
-//		ijc3.add(new IntArray(new int[] { 9012, 1294 }));
-//		ijc3.add(new IntArray(new int[] { -4123, -9 }));
-//		ijc4.fill(new long[] { 2314, 1234 });
-//		table.add(ijc0);
-//		table.add(ijc1);
-//		table.add(ijc2);
-//		table.add(ijc3);
-//		table.add(ijc4);
-//
-//		// Create expectations
-//		// NB: Cannot pass parameters to @Before methods
-//		setUpMethodCalls(sessionMock, gatewayMock, scMock, srMock, tableMock,
-//			fileMock, 12l);
-//
-//		final long id = service.uploadTable(credentials, "table", table, 0);
-//
-//		// Confirm method calls made in this order
-//		new VerificationsInOrder() {
-//
-//			{
-//				final omero.grid.Column[] cols;
-//				sessionMock.getGateway();
-//				sessionMock.getSecurityContext();
-//				gatewayMock.getSharedResources(scMock);
-//				srMock.newTable(anyInt, anyString);
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData(cols = withCapture()); // Capture OMERO columns
-//				tableMock.getOriginalFile();
-//				fileMock.getId();
-//				tableMock.close();
-//
-//				// Tests
-//				// NB: Tests must occur in verification
-//				assertEquals(id, 12l);
-//				assertEquals(cols.length, table.getColumnCount());
-//
-//				assertTrue(omero.grid.BoolColumn.class.isInstance(cols[0]));
-//				assertTrue(omero.grid.DoubleColumn.class.isInstance(cols[1]));
-//				assertTrue(omero.grid.StringColumn.class.isInstance(cols[2]));
-//				assertTrue(omero.grid.LongArrayColumn.class.isInstance(cols[3]));
-//				assertTrue(omero.grid.RoiColumn.class.isInstance(cols[4]));
-//
-//				final omero.grid.BoolColumn oc0 = (omero.grid.BoolColumn) cols[0];
-//				final omero.grid.DoubleColumn oc1 = (omero.grid.DoubleColumn) cols[1];
-//				final omero.grid.StringColumn oc2 = (omero.grid.StringColumn) cols[2];
-//				final omero.grid.LongArrayColumn oc3 =
-//					(omero.grid.LongArrayColumn) cols[3];
-//				final omero.grid.RoiColumn oc4 = (omero.grid.RoiColumn) cols[4];
-//
-//				assertEquals(oc0.name, "h0");
-//				assertEquals(oc1.name, "h1");
-//				assertEquals(oc2.name, "h2");
-//				assertEquals(oc3.name, "h3");
-//				assertEquals(oc4.name, "h4");
-//
-//				assertEquals(oc0.values.length, ijc0.size());
-//				assertEquals(oc1.values.length, ijc1.size());
-//				assertEquals(oc2.values.length, ijc2.size());
-//				assertEquals(oc3.values.length, ijc3.size());
-//				assertEquals(oc4.values.length, ijc4.size());
-//
-//				assertEquals(oc2.size, 3);
-//				assertEquals(oc3.size, 2);
-//
-//				for (int i = 0; i < oc0.values.length; i++) {
-//					assertEquals(oc0.values[i], ijc0.getValue(i));
-//				}
-//				for (int i = 0; i < oc1.values.length; i++) {
-//					assertEquals(oc1.values[i], ijc1.getValue(i), 0);
-//				}
-//				for (int i = 0; i < oc2.values.length; i++) {
-//					assertEquals(oc2.values[i], ijc2.getValue(i));
-//				}
-//				for (int i = 0; i < oc3.values.length; i++) {
-//					assertEquals(oc3.values[i].length, ijc3.get(i).getArray().length);
-//					for (int j = 0; j < oc3.values[0].length; j++) {
-//						assertEquals(oc3.values[i][j], ijc3.get(i).getArray()[j]);
-//					}
-//				}
-//				for (int i = 0; i < oc4.values.length; i++) {
-//					assertEquals(oc4.values[i], ijc4.getValue(i));
-//				}
-//			}
-//		};
-//	}
-//
-//	// -- Helper methods --
-//
-//	private void setUpMethodCalls(final DefaultOMEROSession sessionMock,
-//		final Gateway gatewayMock, final SecurityContext scMock,
-//		final omero.grid.SharedResourcesPrx srMock, final TablePrx tableMock,
-//		final OriginalFile fileMock, final long tableID) throws ServerError,
-//		PermissionDeniedException, CannotCreateSessionException,
-//		DSOutOfServiceException
-//	{
-//		new NonStrictExpectations() {
-//
-//			{
-//				new DefaultOMEROSession(withNotNull());
-//				sessionMock.getGateway();
-//				result = gatewayMock;
-//				sessionMock.getSecurityContext();
-//				result = scMock;
-//				gatewayMock.getSharedResources(scMock);
-//				result = srMock;
-//				srMock.newTable(1, "table");
-//				result = tableMock;
-//
-//				tableMock.initialize((omero.grid.Column[]) any);
-//				tableMock.addData((omero.grid.Column[]) any);
-//				tableMock.getOriginalFile();
-//				result = fileMock;
-//				fileMock.getId();
-//				result = omero.rtypes.rlong(tableID);
-//
-//				tableMock.close();
-//			}
-//		};
-//	}
+	private void assertHeadersEqual(final String imageJ, final String omero,
+		final int index)
+	{
+		if (imageJ == null) assertEquals("" + index, omero);
+		else assertEquals(imageJ, omero);
+	}
+
+	private void assertColDataEquals(final Object imageJ, final Object omero) {
+		if (omero instanceof Long && imageJ instanceof Number) assertEquals(
+			((Number) imageJ).longValue(), ((Long) omero).longValue());
+		else if (omero instanceof Double && imageJ instanceof Number) assertEquals(
+			((Number) imageJ).doubleValue(), ((Double) omero).doubleValue(), 0);
+		else if (omero instanceof Long[]) {
+			final Long[] omeroArray = (Long[]) omero;
+			final Object[] imageJArray = ((PrimitiveArray<?, ?>) imageJ).toArray();
+			for (int i = 0; i < imageJArray.length; i++) {
+				assertEquals(((Number) imageJArray[i]).longValue(), omeroArray[i]
+					.longValue());
+			}
+		}
+		else if (omero instanceof Double[]) {
+			final Double[] omeroArray = (Double[]) omero;
+			final Object[] imageJArray = ((PrimitiveArray<?, ?>) imageJ).toArray();
+			for (int i = 0; i < imageJArray.length; i++) {
+				assertEquals(((Number) imageJArray[i]).doubleValue(), omeroArray[i]
+					.doubleValue(), 0);
+			}
+		}
+		else if (imageJ instanceof Character) assertEquals(((Character) imageJ)
+			.toString(), omero);
+		else if (omero instanceof DataObject) {
+			assertEquals(imageJ, ((DataObject) omero).getId());
+		}
+		else assertEquals(imageJ, omero);
+	}
 
 }

--- a/src/test/java/net/imagej/omero/UploadTableTest.java
+++ b/src/test/java/net/imagej/omero/UploadTableTest.java
@@ -123,7 +123,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -181,7 +180,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -235,7 +233,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -297,7 +294,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -358,7 +354,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -427,7 +422,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -499,7 +493,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -561,7 +554,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification
@@ -632,7 +624,6 @@ public class UploadTableTest {
 				tableMock.getOriginalFile();
 				fileMock.getId();
 				tableMock.close();
-				sessionMock.close();
 
 				// Tests
 				// NB: Tests must occur in verification


### PR DESCRIPTION
Hello,

These commits add the functionality to import/export ImageJ tables to/from OMERO. Most of the OMERO column types can be downloaded to ImageJ with the exception of `omero.grid.MaskColumn`. These changes also include the functionality to attach newly created images to their source OMERO dataset(s), and to attach newly created tables to their source image(s) in OMERO. This change may resolve #22 and/or #23 .

The tests on this branch utilize the mocking framework JMockit. I was going to manually mock the classes, but I couldn't figure out how to mock around the DefaultOMEROSession constructor call in both the uploadTable and downloadTable methods. 

All the commits on the branch build with passing tests. I also tested that these changes work when running ImageJ scripts from OMERO,

@ctrueden if you could please review this branch at your earliest convenience, I would greatly appreciate it.

Please let me know if you have any questions or concerns. 

Thanks!
