### PR TITLE
Introduce OMERO integration test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.settings/
 /target/
+.*un~
+.omero

--- a/.omeroci/test-data
+++ b/.omeroci/test-data
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Set up the data structure needed for the tests
+
+set -e
+set -u
+set -x
+
+OMERO_DIST=${OMERO_DIST:-/opt/omero/server/OMERO.server}
+WORKDIR=$(mktemp -d)
+
+function cleanup {
+  rm -rf "$WORKDIR"
+  echo "Deleted temp working directory $WORKDIR"
+}
+
+trap cleanup EXIT
+
+export PATH=$PATH:${OMERO_DIST}/bin
+omero login root@localhost -w omero
+DATASET=$(omero obj new Dataset name=TestDataset)
+PROJECT=$(omero obj new Project name=TestProject)
+omero obj new ProjectDatasetLink parent=$PROJECT child=$DATASET
+FILENAME="$WORKDIR/test&rectangle=10&ellipsis=10&points=10.fake"
+touch "$FILENAME"
+IMAGE=$(omero import --output=ids  "$FILENAME" -T Dataset:id:1)
+
+OPEN=$(omero obj new TagAnnotation textValue=open description=boundaryType)
+CLOSED=$(omero obj new TagAnnotation textValue=closed description=boundaryType)
+
+# TBD
+# for x in $(seq 0 9);
+# do
+#     omero obj new ShapeAnnotationLink parent=Rectangle: child=$OPEN
+# done

--- a/.omeroci/test-data
+++ b/.omeroci/test-data
@@ -21,15 +21,17 @@ omero login root@localhost -w omero
 DATASET=$(omero obj new Dataset name=TestDataset)
 PROJECT=$(omero obj new Project name=TestProject)
 omero obj new ProjectDatasetLink parent=$PROJECT child=$DATASET
+
 FILENAME="$WORKDIR/test&rectangle=10&ellipsis=10&points=10.fake"
 touch "$FILENAME"
-IMAGE=$(omero import --output=ids  "$FILENAME" -T Dataset:id:1)
+IMAGE=$(omero import --output=ids "$FILENAME" -T $DATASET)
 
 OPEN=$(omero obj new TagAnnotation textValue=open description=boundaryType)
 CLOSED=$(omero obj new TagAnnotation textValue=closed description=boundaryType)
-
-# TBD
-# for x in $(seq 0 9);
-# do
-#     omero obj new ShapeAnnotationLink parent=Rectangle: child=$OPEN
-# done
+QUERY="select s from Dataset d join d.imageLinks dil join dil.child as i join i.rois as r join r.shapes as s where d.id = ${DATASET##Dataset:}"
+for shape in $(omero -q hql --style=csv "$QUERY" | grep -v Class);
+do
+    class=$(echo $shape | awk -F, '{print $2}' | tr -d I)
+    oid=$(echo $shape | awk -F, '{print $3}')
+    omero obj new ShapeAnnotationLink parent=$class:$oid child=$OPEN
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 jdk: oraclejdk8
+sudo: required
+services:
+  - docker
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
   only:
   - master
   - "/.*-[0-9]+\\..*/"
+cache:
+  directories:
+    - $HOME/.m2
 install: true
 script: ".travis/build.sh"
 env:

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Required for mounting m2 into docker
+mkdir -p $HOME/.m2
 chmod a+rw $HOME/.m2
 
 curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,4 +8,8 @@ curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/trav
 sh travis-build.sh
 
 git clone git://github.com/openmicroscopy/omero-test-infra .omero
-env DOCKER_ARGS="-v $HOME/.m2:/home/mvn/.m2" .omero/lib-docker
+# FIXME: setting DOCKER_ARGS here should work but it's not.
+# It fails with:
+# [ERROR] Could not create local repository at /home/mvn/.m2/repository -> [Help 1]
+# env DOCKER_ARGS="-v $HOME/.m2:/home/mvn/.m2"
+.omero/lib-docker

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -3,4 +3,4 @@ curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/trav
 sh travis-build.sh
 
 git clone git://github.com/openmicroscopy/omero-test-infra .omero
-.omero/lib-docker
+env DOCKER_ARGS="-v $HOME/.m2:/home/mvn/.m2" .omero/lib-docker

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
 sh travis-build.sh
+
+git clone git://github.com/openmicroscopy/omero-test-infra .omero
+.omero/lib-docker

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Required for mounting m2 into docker
+chmod a+rw $HOME/.m2
+
 curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/master/travis-build.sh
 sh travis-build.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3-jdk-8-alpine
+
+COPY . /src
+RUN adduser -S mvn
+RUN chown -R mvn /src
+
+USER mvn
+WORKDIR /src
+RUN mvn dependency:resolve
+RUN mvn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ RUN chown -R mvn /src
 
 USER mvn
 WORKDIR /src
-RUN mvn dependency:resolve
-RUN mvn install
+CMD mvn install


### PR DESCRIPTION
 * Extends build.sh to clone omero-test-infra and
   invoke lib-docker, a framework for testing
   libraries which require a running OMERO instance
   for integration tests
 * Adds a Dockerfile which at the moment only
   builds imagej-omero but a command to run
   integration can be added later to the end
   of the Dockerfile to connect to host "omero"