### PR TITLE
Fix Integration Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,6 @@
 
 		<!-- Test configuration -->
 		<skipITs>true</skipITs>
-		<groups>net.imagej.omero.it.IntegrationTest</groups>
-		<excludedGroups>net.imagej.omero.it.IntegrationTest</excludedGroups>
 
 		<jmockit.version>1.33</jmockit.version>
 	</properties>
@@ -185,4 +183,31 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 	</dependencies>
+
+	<!-- NB: JUnit and JMockit both contain the JUnit runner class -->
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludedGroups>net.imagej.omero.it.IntegrationTest</excludedGroups>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<skipITs>${skipITs}</skipITs>
+					<groups>net.imagej.omero.it.IntegrationTest</groups>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
The integration tests are not currently running on master, due to changes in commit 2869cc8c5ba1aed148637b44f5946a64fd845c13. The commit on this branch reverts this.

Whether or not this is actually the desired solution is still up for debate.