### PR TITLE
Workaround SSLHandshakeException with OMERO 5.4

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -22,6 +22,8 @@ fi
 # [ERROR] Could not create local repository at /home/mvn/.m2/repository -> [Help 1]
 # env DOCKER_ARGS="-v $HOME/.m2:/home/mvn/.m2"
 
+# TODO: remove SSLUtils when bumping to 5.5
+# see: https://github.com/imagej/imagej-omero/pull/105
 export OMERO_SERVER_VERSION=5.4
 export OMERO_WEB_VERSION=5.4
 export COMPOSE_FILE="docker-compose.yml:volumes.yml"

--- a/src/main/java/net/imagej/omero/DefaultOMEROSession.java
+++ b/src/main/java/net/imagej/omero/DefaultOMEROSession.java
@@ -63,6 +63,10 @@ import omero.model.PixelsType;
  */
 public class DefaultOMEROSession implements OMEROSession {
 
+        static {
+                net.imagej.omero.SSLUtils.fixDisabledAlgorithms();
+        }
+
 	// -- Fields --
 
 	private omero.client client;

--- a/src/main/java/net/imagej/omero/SSLUtils.java
+++ b/src/main/java/net/imagej/omero/SSLUtils.java
@@ -39,6 +39,7 @@ public class SSLUtils {
 	 * OMERO 5.5 will no longer require this. See:
 	 * https://github.com/openmicroscopy/openmicroscopy/pull/5949/
 	 */
+	@Deprecated
 	public static void fixDisabledAlgorithms() {
 		final String property = "jdk.tls.disabledAlgorithms";
 		final String value = Security.getProperty(property);

--- a/src/main/java/net/imagej/omero/SSLUtils.java
+++ b/src/main/java/net/imagej/omero/SSLUtils.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2013 - 2019 Open Microscopy Environment:
+ * 	- Board of Regents of the University of Wisconsin-Madison
+ * 	- Glencoe Software, Inc.
+ * 	- University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package net.imagej.omero;
+
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ */
+public class SSLUtils {
+
+	/**
+	 * Ensure that anonymous cipher suites are enabled in the JRE.
+	 * OMERO 5.5 will no longer require this. See:
+	 * https://github.com/openmicroscopy/openmicroscopy/pull/5949/
+	 */
+	public static void fixDisabledAlgorithms() {
+		final String property = "jdk.tls.disabledAlgorithms";
+		final String value = Security.getProperty(property);
+		if (!(value == null || value.trim().isEmpty())) {
+			final List<String> algorithms = new ArrayList<>();
+			boolean isChanged = false;
+			for (String algorithm : value.split(",")) {
+				algorithm = algorithm.trim();
+				if (algorithm.isEmpty()) {
+					/* ignore */
+				} else if ("anon".equals(algorithm.toLowerCase())) {
+					isChanged = true;
+				} else {
+					algorithms.add(algorithm);
+				}
+			}
+			if (isChanged) {
+				boolean needsComma = false;
+				final StringBuilder newValue = new StringBuilder();
+				for (final String algorithm : algorithms) {
+					if (needsComma) {
+						newValue.append(", ");
+					} else {
+						needsComma = true;
+					}
+					newValue.append(algorithm);
+				}
+				Security.setProperty(property, newValue.toString());
+			}
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/omero/ScriptRunner.java
+++ b/src/main/java/net/imagej/omero/ScriptRunner.java
@@ -43,6 +43,10 @@ import org.scijava.plugin.Parameter;
  */
 public class ScriptRunner extends AbstractContextual {
 
+        static {
+                net.imagej.omero.SSLUtils.fixDisabledAlgorithms();
+        }
+
 	// -- Fields --
 
 	@Parameter

--- a/src/main/java/net/imagej/omero/commands/OpenFromOMERO.java
+++ b/src/main/java/net/imagej/omero/commands/OpenFromOMERO.java
@@ -61,6 +61,10 @@ import omero.ServerError;
 })
 public class OpenFromOMERO extends OMEROCommand {
 
+        static {
+                net.imagej.omero.SSLUtils.fixDisabledAlgorithms();
+        }
+
 	@Parameter
 	private LogService log;
 

--- a/src/test/java/net/imagej/omero/it/OmeroIT.java
+++ b/src/test/java/net/imagej/omero/it/OmeroIT.java
@@ -36,6 +36,7 @@ import io.scif.services.DatasetIOService;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -82,6 +83,10 @@ import omero.gateway.model.TableData;
  */
 @Category(IntegrationTest.class)
 public class OmeroIT {
+
+	static {
+		net.imagej.omero.SSLUtils.fixDisabledAlgorithms();
+	}
 
 	private omero.client client;
 	private OMEROLocation cred;

--- a/src/test/java/net/imagej/omero/it/OmeroIT.java
+++ b/src/test/java/net/imagej/omero/it/OmeroIT.java
@@ -36,7 +36,6 @@ import io.scif.services.DatasetIOService;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 


### PR DESCRIPTION
OMERO uses Ice's ADH settings to connect without the need
to install a certificate by default. Newer JDKs are disabling
more and more ciphers. In order to continue working with older
server versions, the ciphers need to be added back *before*
any other code loads the SSL subsystem in a JVM. This patch
places a static block at the beginning of all classes which
call `new omero.client` in order to be as defensive as possible.

see:
 - https://gitter.im/imagej/imagej?at=5cd329370824230a77ff24dd
 - https://travis-ci.org/imagej/imagej-omero/jobs/529909300#L3040
 - https://github.com/openmicroscopy/openmicroscopy/pull/5949