### PR TITLE
Fixes a NPE when omeroAnnotations do not contain the pixelsID key

### DIFF
--- a/src/main/java/net/imagej/omero/OMEROSession.java
+++ b/src/main/java/net/imagej/omero/OMEROSession.java
@@ -900,10 +900,12 @@ public class OMEROSession /*extends AbstractContextual*/ implements Closeable {
 		Map<Long, List<IObject>> omeroAnnotations = sfp.getMetadataService()
 			.loadAnnotations("omero.model.Image", Arrays.asList(pixelsID), null, null,
 				null);
-		for (IObject o : omeroAnnotations.get(pixelsID)) {
-			if (o instanceof MapAnnotationI) {
-				MapAnnotationI mapAnnotation = (MapAnnotationI) o;
-				annotations.putAll(mapAnnotation.getMapValueAsMap());
+		if (omeroAnnotations.containsKey(pixelsID)) {
+			for (IObject o : omeroAnnotations.get(pixelsID)) {
+				if (o instanceof MapAnnotationI) {
+					MapAnnotationI mapAnnotation = (MapAnnotationI) o;
+					annotations.putAll(mapAnnotation.getMapValueAsMap());
+				}
 			}
 		}
 		return annotations;


### PR DESCRIPTION
I encounteered a NPE when trying to open an image by using imagej-omero on our omero server. I experienced this issue both in the IDE and within an up-to-date Fiji.

This is a fix that prevents the NPE. The image is then opened fine.  This fix prevents the NPE to occur and allows to open the image. But I do not now if it is the right fix: maybe these `omeroAnnotations` should always be non-empty with the requested pixelsID`. @hinerm what's your opinion on this ?